### PR TITLE
#234 checking a list of ServiceType values when resolving the URL

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/DefaultEndpointURLResolver.java
@@ -63,7 +63,7 @@ public class DefaultEndpointURLResolver implements EndpointURLResolver {
 
 	private String resolveV2(URLResolverParams p) {
 		for (Service sc : p.access.getServiceCatalog()) {
-			if (p.type.getServiceName().equals(sc.getName()) || p.type.name().toLowerCase().equals(sc.getType()) || p.type.getServiceName().equals(sc.getType()))
+			if (p.type.getServiceName().equals(sc.getName()) || p.type == ServiceType.forName(sc.getType()))
 			{
 				for (Endpoint ep : sc.getEndpoints())
 				{


### PR DESCRIPTION
The Volume management the Openstack4J fails on HP Cloud, because the Block Storage type is volume on HP Cloud and not cinder.