### PR TITLE
Mark resolution of LoggerFactorySupplier as optional in OSGi.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,7 +91,7 @@
 						<Require-Capability>
 							osgi.serviceloader; filter:="(osgi.serviceloader=org.openstack4j.api.APIProvider)";cardinality:=multiple,
 							osgi.serviceloader; filter:="(osgi.serviceloader=org.openstack4j.core.transport.HttpExecutorService)";cardinality:=multiple,
-							osgi.serviceloader; filter:="(osgi.serviceloader=org.openstack4j.openstack.logging.LoggerFactorySupplier)";cardinality:=multiple,
+							osgi.serviceloader; filter:="(osgi.serviceloader=org.openstack4j.openstack.logging.LoggerFactorySupplier)";cardinality:=multiple;resolution:=optional,
 							osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)",
 							osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"
 						</Require-Capability>

--- a/src/main/resources/features.xml
+++ b/src/main/resources/features.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0" name="openstack4j">
+
+	<feature name="openstack4j-httpclient-log4j" version="${project.version}">
+		<feature version="${project.version}">openstack4j-httpclient</feature>
+		<feature version="${project.version}">openstack4j-plugin-log4j</feature>
+	</feature>
+	
 	<!-- 
-		Due to SPI in OSGi requirements, at least one provider for an HTTPExecutorService and another for LoggerFactorySupplier 
+		Due to SPI in OSGi requirements, at least one provider for an HTTPExecutorService 
 		must be present in the OSGi container for the core to be successfully resolved.
 	 -->
-	<feature name="openstack4j-httpclient-log4j" version="${project.version}">
+	<feature name="openstack4j-httpclient" version="${project.version}">
 		<feature version="${project.version}">openstack4j-core</feature>
 		<feature version="${project.version}">openstack4j-connector-httpclient</feature>
-		<feature version="${project.version}">openstack4j-plugin-log4j</feature>
 	</feature>
 
 	<!--


### PR DESCRIPTION
This patch is related with issue #214

It addresses an issue with default provider mechanism used in openstack4j-core with FallbackLoggerFactorySupplier not working in OSGi.

This mechanism do work now both in OSGi and in "normal" java environments.
FallbackLoggerFactorySupplier will be used in case no LoggerFactorySupplier provider is available.