### PR TITLE
change state type in ResetAction from enum to String

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/ResetStateAction.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/actions/ResetStateAction.java
@@ -16,17 +16,27 @@ public class ResetStateAction implements ServerAction {
     private static final long serialVersionUID = 1L;
     
     @JsonProperty("state")
-    private final Status state;
+    private final String state;
     
     public ResetStateAction(Status state) {
-        this.state = state;
+		switch (state) {
+		case ACTIVE:
+			this.state = "active";
+			break;
+		case ERROR:
+			this.state = "error";
+			break;
+		default:
+			this.state = "active";
+			break;
+		}
     }
     
     public static ResetStateAction create(Status state) {
         return new ResetStateAction(state);
     }
 
-    public Status getState() {
+    public String getState() {
         return state;
     }
 }


### PR DESCRIPTION
#258 when i use resetStateAction, openstack returns error like:
![default](https://cloud.githubusercontent.com/assets/5234067/6684788/6f265894-cccf-11e4-97ba-1403fb1709f0.png) ,I change ResetStateAction.state form enmu to string, and it works well now.I'm not sure wheather it's hard code, just for reference.
