### PR TITLE
Add format=json parameter to Swift GETs for container list and object list

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageContainerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageContainerServiceImpl.java
@@ -38,7 +38,7 @@ public class ObjectStorageContainerServiceImpl extends BaseObjectStorageService 
      */
     @Override
     public List<? extends SwiftContainer> list() {
-          return toList(get(SwiftContainerImpl[].class).execute());
+          return toList(get(SwiftContainerImpl[].class).param("format", "json").execute());
     }
 
     /**
@@ -49,7 +49,7 @@ public class ObjectStorageContainerServiceImpl extends BaseObjectStorageService 
         if (options == null)
             return list();
         
-        return toList(get(SwiftContainerImpl[].class).params(options.getOptions()).execute());
+        return toList(get(SwiftContainerImpl[].class).param("format", "json").params(options.getOptions()).execute());
     }
     
     /**

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -42,7 +42,7 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
     @Override
     public List<? extends SwiftObject> list(String containerName) {
         checkNotNull(containerName);
-        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", containerName)).execute();
+        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", containerName)).param("format", "json").execute();
         return Lists.transform(objs, ApplyContainerToObjectFunction.create(containerName));
     }
 
@@ -53,7 +53,7 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
         
         checkNotNull(containerName);
         
-        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", containerName)).params(options.getOptions()).execute();
+        List<SwiftObjectImpl> objs = get(SwiftObjects.class, uri("/%s", containerName)).param("format", "json").params(options.getOptions()).execute();
         return Lists.transform(objs, ApplyContainerToObjectFunction.create(containerName));
                 
     }


### PR DESCRIPTION
Documentation lists format=plain as default so the Json Parser errors out without specifically setting it to json