### PR TITLE
Changes in NeutronFirewallPolicy.

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallPolicyTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallPolicyTests.java
@@ -60,7 +60,6 @@ public class FirewallPolicyTests extends AbstractTest {
 		FirewallPolicy create = Builders.firewallPolicy()
 				  .name("Test-Firewall-Policy").description("Test-Firewall-Policy")
 				  .shared(Boolean.TRUE).audited(Boolean.FALSE)
-				  .firewallRules(Arrays.asList("8722e0e0-9cc9-4490-9660-8c9a5732fbb0"))
 				  .tenantId("45977fa2dbd7482098dd68d0d8970117").build();
 		FirewallPolicy result = os().networking().firewalls().firewallpolicy().create(create);
 		Logger.getLogger(getClass().getName()).info(getClass().getName() + " : Created FirewallPolicy : "+result);

--- a/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallPolicyTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallPolicyTests.java
@@ -29,6 +29,7 @@ public class FirewallPolicyTests extends AbstractTest {
 	
 	private static final String FIREWALL_POLICY = "/network/firewalls/firewallpolicy.json";
 	private static final String FIREWALL_POLICIES = "/network/firewalls/firewallpolicies.json";
+	private static final String FIREWALL_POLICY_RULE = "/network/firewalls/firewallpolicyrule.json";
 	private static final String FIREWALL_POLICY_UPDATE = "/network/firewalls/firewallpolicyupdate.json";
 	
 	public void testListFirewallPolicies() throws IOException {
@@ -82,7 +83,7 @@ public class FirewallPolicyTests extends AbstractTest {
 	}
 	
 	public void testInsertRuleInFirewallPolicy() throws IOException {
-		respondWith(FIREWALL_POLICY);
+		respondWith(FIREWALL_POLICY_RULE);
 		
 		FirewallPolicy result = os().networking().firewalls().firewallpolicy()
 				.insertFirewallRuleInPolicy(
@@ -94,7 +95,7 @@ public class FirewallPolicyTests extends AbstractTest {
 	}
 	
 	public void testRemoveRuleFromFirewallPolicy() throws IOException {
-		respondWith(FIREWALL_POLICY);
+		respondWith(FIREWALL_POLICY_RULE);
 		
 		FirewallPolicy result = os().networking().firewalls().firewallpolicy()
 				.removeFirewallRuleFromPolicy("c69933c1-b472-44f9-8226-30dc4ffd454c", "7bc34b8c-8d3b-4ada-a9c8-1f4c11c65692");

--- a/core-test/src/main/resources/network/firewalls/firewallpolicyrule.json
+++ b/core-test/src/main/resources/network/firewalls/firewallpolicyrule.json
@@ -1,0 +1,13 @@
+{
+    "audited": false,
+    "description": "",
+    "firewall_list": [],
+    "firewall_rules": [
+        "a08ef905-0ff6-4784-8374-175fffe7dade",
+        "8722e0e0-9cc9-4490-9660-8c9a5732fbb0"
+    ],
+    "id": "c69933c1-b472-44f9-8226-30dc4ffd454c",
+    "name": "test-policy",
+    "shared": false,
+    "tenant_id": "45977fa2dbd7482098dd68d0d8970117"
+}

--- a/core/src/main/java/org/openstack4j/model/network/ext/FirewallPolicy.java
+++ b/core/src/main/java/org/openstack4j/model/network/ext/FirewallPolicy.java
@@ -59,6 +59,12 @@ public interface FirewallPolicy extends ModelEntity, Buildable<FirewallPolicyBui
 	 	* The firewall applies the rules in the order in which they appear in this list.
 	 */
 	public List<String> getFirewallRuleIds();
+	
+	/**
+	 * @return firewallList(UUID)List : This is a list of Firewalls associated with Firewall Policy.
+	 * 		This is returned when a firewall rule is added or removed from a firewall policy.
+	 */
+	public List<String> getFirewallList();
 
 	/**
 	 * @see FirewallRule

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/AbstractNeutronFirewallPolicy.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/AbstractNeutronFirewallPolicy.java
@@ -1,0 +1,210 @@
+package org.openstack4j.openstack.networking.domain.ext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openstack4j.api.Apis;
+import org.openstack4j.model.network.ext.FirewallPolicy;
+import org.openstack4j.model.network.ext.FirewallRule;
+import org.openstack4j.model.network.ext.builder.FirewallPolicyBuilder;
+import org.openstack4j.openstack.common.ListResult;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+/**
+ * A Neutron Firewall (FwaaS) : Firewall Policy Entity.
+ * 
+ * <p>This is the Parent class which is extended by {@link NeutronFirewallPolicy} & {@link NeutronFirewalPolicyRule} classes.
+	* Prior has `@JsonRootName("firewall_policy")` attribute whereas the later doesn't have 
+	* (which is used by `rule_insert/rule_remove` calls - which doesn't require JsonRootName).</p> 
+ * 
+ * @see NeutronFirewallPolicy
+ * @see NeutronFirewallPolicyRule
+ * 
+ * @author Vishvesh Deshmukh
+ */
+public class AbstractNeutronFirewallPolicy implements FirewallPolicy {
+	
+	private static final long serialVersionUID = 1L;
+	
+	protected String id;
+	
+	protected String name;
+	
+	@JsonProperty("tenant_id")
+	protected String tenantId;
+	
+	protected String description;
+	
+	protected Boolean shared;
+	
+	protected Boolean audited;
+	
+	@JsonProperty("firewall_rules")
+	protected List<String> firewallRules;
+	
+	protected List<NeutronFirewallRule> neutronFirewallRules;
+	
+	@JsonProperty("firewall_list")
+	private List<String> firewallList;
+		
+	/**
+	 * Wrap this FirewallPolicy to a builder
+	 * @return FirewallPolicyBuilder
+	 */
+	@Override
+	public FirewallPolicyBuilder toBuilder() {
+		return new FirewallPolicyConcreteBuilder(this);
+	}
+	
+	/**
+	 * @return FirewallPolicyBuilder
+	 */
+	public static FirewallPolicyBuilder builder() {
+		return new FirewallPolicyConcreteBuilder();
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+	
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getTenantId() {
+		return tenantId;
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public Boolean isShared() {
+		return shared != null && shared;
+	}
+	
+	@Override
+	public Boolean isAudited() {
+		return audited != null && audited;
+	}
+
+	@JsonIgnore
+	@Override
+	public List<String> getFirewallRuleIds() {
+		return firewallRules;
+	}
+
+	@Override
+	public List<? extends FirewallRule> getNeutronFirewallRules() {
+        if (neutronFirewallRules == null && (firewallRules != null && firewallRules.size() > 0)) {
+        	neutronFirewallRules = new ArrayList<NeutronFirewallRule>();
+            for (String ruleId : firewallRules) {
+                NeutronFirewallRule rule = (NeutronFirewallRule) Apis.getNetworkingServices().
+                		firewalls().firewallrule().get(ruleId);
+                neutronFirewallRules.add(rule);
+            }
+        }
+        return neutronFirewallRules;
+	}
+
+	@Override
+	public List<String> getFirewallList() {
+		return firewallList;
+	}
+	
+	@Override
+	public String toString() {
+		return Objects.toStringHelper(this).omitNullValues()
+				.add("id", id).add("name", name).add("shared", shared).add("audited", audited)
+				.add("tenantId", tenantId).add("description", description)
+				.add("firewallRuleIds", firewallRules).add("neutronFirewallRules", neutronFirewallRules)
+				.add("firewallList", firewallList)
+				.toString();
+	}
+	
+	public static class FirewallPolicies extends ListResult<NeutronFirewallPolicy> {
+
+		private static final long serialVersionUID = 1L;
+		
+		@JsonProperty("firewall_policies")
+		List<NeutronFirewallPolicy> firewallPolicies;
+		
+		@Override
+		public List<NeutronFirewallPolicy> value() {
+			return firewallPolicies;
+		}
+		
+		@Override
+		public String toString() {
+			return Objects.toStringHelper(this).omitNullValues()
+					.add("firewallPolicies", firewallPolicies).toString();
+		}
+	}
+	
+	public static class FirewallPolicyConcreteBuilder implements FirewallPolicyBuilder {
+		NeutronFirewallPolicy f;
+		
+		@Override
+		public FirewallPolicy build() {
+			return f;
+		}
+		
+		public FirewallPolicyConcreteBuilder() {
+			this(new NeutronFirewallPolicy());
+		}
+		
+		public FirewallPolicyConcreteBuilder(FirewallPolicy f) {
+			this.f = (NeutronFirewallPolicy) f;
+		}
+		
+		@Override
+		public FirewallPolicyBuilder from(FirewallPolicy in) {
+			this.f = (NeutronFirewallPolicy) in;
+			return this;
+		}
+
+		@Override
+		public FirewallPolicyBuilder tenantId(String tenantId) {
+			f.tenantId = tenantId;
+			return this;
+		}
+
+		@Override
+		public FirewallPolicyBuilder name(String name) {
+			f.name = name;
+			return this;
+		}
+
+		@Override
+		public FirewallPolicyBuilder description(String description) {
+			f.description = description;
+			return this;
+		}
+
+		@Override
+		public FirewallPolicyBuilder shared(Boolean shared) {
+			f.shared = shared;
+			return this;
+		}
+
+		@Override
+		public FirewallPolicyBuilder audited(Boolean audited) {
+			f.audited = audited;
+			return this;
+		}
+
+		@Override
+		public FirewallPolicyBuilder firewallRules(List<String> ruleIdList) {
+			f.firewallRules = ruleIdList;
+			return this;
+		}
+	}
+}

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronFirewallPolicyRule.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronFirewallPolicyRule.java
@@ -1,20 +1,18 @@
 package org.openstack4j.openstack.networking.domain.ext;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonRootName;
 
 /**
- *
  * A Neutron Firewall (FwaaS) : Firewall Policy Entity.
  * 
- * <p>This is the child class of {@link AbstractNeutronFirewallPolicy} - which requires JsonRootName <code>firewall_policy</code>.</p> 
+ * <p>This is the child class of {@link AbstractNeutronFirewallPolicy} which is used by `rule_insert/rule_remove` calls 
+ * - which doesn't require JsonRootName <code>firewall_policy</code>.</p> 
  * 
  * @see AbstractNeutronFirewallPolicy
  * 
  * @author Vishvesh Deshmukh
  */
-@JsonRootName("firewall_policy")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class NeutronFirewallPolicy extends AbstractNeutronFirewallPolicy {
+public class NeutronFirewallPolicyRule extends AbstractNeutronFirewallPolicy {
 	private static final long serialVersionUID = 1L;
 }

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallPolicyServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallPolicyServiceImpl.java
@@ -13,10 +13,11 @@ import org.openstack4j.model.compute.ActionResponse;
 import org.openstack4j.model.network.ext.FirewallPolicy;
 import org.openstack4j.model.network.ext.FirewallPolicyUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
+import org.openstack4j.openstack.networking.domain.ext.AbstractNeutronFirewallPolicy.FirewallPolicies;
 import org.openstack4j.openstack.networking.domain.ext.FirewallRuleStrategy;
 import org.openstack4j.openstack.networking.domain.ext.FirewallRuleStrategy.RuleInsertStrategyType;
 import org.openstack4j.openstack.networking.domain.ext.NeutronFirewallPolicy;
-import org.openstack4j.openstack.networking.domain.ext.NeutronFirewallPolicy.FirewallPolicies;
+import org.openstack4j.openstack.networking.domain.ext.NeutronFirewallPolicyRule;
 import org.openstack4j.openstack.networking.internal.BaseNetworkingServices;
 
 /**
@@ -92,11 +93,9 @@ public class FirewallPolicyServiceImpl extends BaseNetworkingServices implements
 	@Override
 	public FirewallPolicy insertFirewallRuleInPolicy(
 			String firewallPolicyId, String firewallRuleId, RuleInsertStrategyType type, String insertAfterOrBeforeRuleId) {
-	  checkNotNull(firewallPolicyId);
-	  checkNotNull(type);
-	  checkNotNull(firewallRuleId);
-	  checkNotNull(insertAfterOrBeforeRuleId);
-		return put(NeutronFirewallPolicy.class, uri("/fw/firewall_policies/%s/insert_rule", firewallPolicyId))
+		checkNotNull(firewallPolicyId);
+		checkNotNull(firewallRuleId);
+		return put(NeutronFirewallPolicyRule.class, uri("/fw/firewall_policies/%s/insert_rule", firewallPolicyId))
 		          .entity(FirewallRuleStrategy.create(firewallRuleId, type, insertAfterOrBeforeRuleId))
 				  .execute();
 	}
@@ -110,9 +109,9 @@ public class FirewallPolicyServiceImpl extends BaseNetworkingServices implements
 		checkNotNull(firewallRuleId);
 		checkState(!(firewallPolicyId == null && firewallRuleId == null), 
 				"Either a Firewall Policy or Firewall Rule identifier must be set");
-		return put(NeutronFirewallPolicy.class, uri("/fw/firewall_policies/%s/remove_rule", firewallPolicyId))
+		return put(NeutronFirewallPolicyRule.class, uri("/fw/firewall_policies/%s/remove_rule", firewallPolicyId))
 		           .entity(FirewallRuleStrategy.remove(firewallRuleId))
-		           .execute(ExecutionOptions.<NeutronFirewallPolicy>create(PropagateOnStatus.on(404)));
+		           .execute(ExecutionOptions.<NeutronFirewallPolicyRule>create(PropagateOnStatus.on(404)));
 	}
 
 }


### PR DESCRIPTION
1) Separated NeutronFirewallPolicy by creating parent
AbstractNeutronFirewallPolicy class which is extended by
NeutronFirewallPolicy & NeutronFirewalPolicyRule classes.
	     --> Prior has `@JsonRootName("firewall_policy")` attribute whereas the
later doesn't have (which is used by `rule_insert/rule_remove` calls -
which doesn't require JsonRootName - `firewall_policy`).
2) Fixed and added `firewallpolicyrule` test cases to add/remove rules
from a policy.
3) Removed null checks for insertRuleInPolicy call for `type` and
`insertAfterOrBeforeRuleId` fields.
4) Added `firewall_list` field in AbstractNeutronFirewallPolicy as this
extra field is returned by OpenStack after `add/remove rule` calls.
5) User can now invoke `insertFirewallRuleInPolicy` with null parameters.
```
FirewallPolicy ruleAdded =  osClient.networking().firewalls().firewallpolicy()
						.insertFirewallRuleInPolicy(policyId, ruleId, null, null);
```