### PR TITLE
Added `@JsonIgnore` back to `getNeutronFirewallRules()`.

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/AbstractNeutronFirewallPolicy.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/AbstractNeutronFirewallPolicy.java
@@ -102,6 +102,7 @@ public class AbstractNeutronFirewallPolicy implements FirewallPolicy {
 		return firewallRules;
 	}
 
+	@JsonIgnore
 	@Override
 	public List<? extends FirewallRule> getNeutronFirewallRules() {
         if (neutronFirewallRules == null && (firewallRules != null && firewallRules.size() > 0)) {


### PR DESCRIPTION
--> Added `@JsonIgnore` back to `getNeutronFirewallRules()` to ignore the field while creating a `FirewallPolicy`..