### PR TITLE
Added @JsonIgnore on getPolicy() in NeutronFirewall while creating Firewall.

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronFirewall.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/ext/NeutronFirewall.java
@@ -7,6 +7,7 @@ import org.openstack4j.model.network.ext.builder.FirewallBuilder;
 import org.openstack4j.openstack.common.ListResult;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
@@ -123,6 +124,7 @@ public class NeutronFirewall implements Firewall {
 		return status;
 	}
 
+	@JsonIgnore
 	@Override
 	public String getPolicy() {
 		return policyId;


### PR DESCRIPTION
Added `@JsonIgnore` on `getPolicy()` in `NeutronFirewall`, as it was adding unwanted `policy` json field while making a `POST/Create` request to OpenStack. This solves the issue.