### PR TITLE
Fix connection leak when mapping HttpResponse to ActionResponse.class…

### DIFF
--- a/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
+++ b/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
@@ -9,112 +9,108 @@ import org.openstack4j.core.transport.functions.ResponseToActionResponse;
 import org.openstack4j.model.compute.ActionResponse;
 
 /**
- * Handles retrieving an Entity from an HttpResponse while validating resulting status codes. 
- * 
+ * Handles retrieving an Entity from an HttpResponse while validating resulting status codes.
+ *
  * @author Jeremy Unruh
  */
 public class HttpEntityHandler {
 
-	public static <T> T handle(HttpResponse response, Class<T> returnType, ExecutionOptions<T> options) {
-		return handle(response, returnType, options, Boolean.FALSE);
-	}
+    public static <T> T handle(HttpResponse response, Class<T> returnType, ExecutionOptions<T> options) {
+        return handle(response, returnType, options, Boolean.FALSE);
+    }
 
-	@SuppressWarnings("unchecked")
-	public static <T> T handle(HttpResponse response, Class<T> returnType, ExecutionOptions<T> options, boolean requiresVoidBodyHandling) {
+    @SuppressWarnings("unchecked")
+    public static <T> T handle(HttpResponse response, Class<T> returnType, ExecutionOptions<T> options, boolean requiresVoidBodyHandling) {
 
-		Handle<T> handle = Handle.create(response, returnType, options, requiresVoidBodyHandling);
+        Handle<T> handle = Handle.create(response, returnType, options, requiresVoidBodyHandling);
 
-		if(response.getStatus() >= 400) {
+        if (response.getStatus() >= 400) {
 
-			if (requiresVoidBodyHandling && ActionResponse.class == returnType) {
-				return (T) ResponseToActionResponse.INSTANCE.apply(response);
-			}
+            if (requiresVoidBodyHandling && ActionResponse.class == returnType) {
+                return (T) ResponseToActionResponse.INSTANCE.apply(response);
+            }
 
-			if (options != null)
-				options.propagate(response);
+            if (options != null) {
+                options.propagate(response);
+            }
 
-			if (handle404(handle).isComplete()) {
-				return handle.getReturnObject();
-			}
-				
-			if (handleLessThan500(handle).isComplete()) {
-				return handle.getReturnObject();
-			}
-			
-			throw mapException(response.getStatusMessage(),
-					response.getStatus());
-		}
+            if (handle404(handle).isComplete()) {
+                return handle.getReturnObject();
+            }
 
-		if (options != null && options.hasParser())
-			return options.getParser().apply(response);
+            if (handleLessThan500(handle).isComplete()) {
+                return handle.getReturnObject();
+            }
 
-		if (returnType == Void.class) 
-			return null;
-		if (returnType == ActionResponse.class) 
-			return (T) ActionResponse.actionSuccess();
+            throw mapException(response.getStatusMessage(), response.getStatus());
+        }
 
-			return response.readEntity(returnType);
-	}
+        if (options != null && options.hasParser()) {
+            return options.getParser().apply(response);
+        }
 
-	private static <T> Handle<T> handle404(Handle<T> handle) {
-		if (handle.getResponse().getStatus() == 404)
-		{
-			
-			if (ListType.class.isAssignableFrom(handle.getReturnType()))
-			{
-				try
-				{
-					return handle.complete(handle.getReturnType().newInstance());
-				} catch (InstantiationException e) {
-					e.printStackTrace();
-				} catch (IllegalAccessException e) {
-					e.printStackTrace();
-				}
-				finally {
-					closeQuietly(handle.getResponse());
-				}
-			}
+        if (returnType == Void.class) {
+            closeQuietly(handle.getResponse());
+            return null;
+        }
+        
+        if (returnType == ActionResponse.class) {
+            closeQuietly(handle.getResponse());
+            return (T) ActionResponse.actionSuccess();
+        }
 
-			if (handle.getReturnType() != ActionResponse.class) {
-				closeQuietly(handle.getResponse());
-				return handle.complete(null);
-			}
-		}
-		
-		return handle.continueHandling();
-	}
-	
-	@SuppressWarnings("unchecked")
-	private static <T> Handle<T> handleLessThan500(Handle<T> handle) {
-		if (handle.getResponse().getStatus() < 500)
-		{
-			try
-			{
+        return response.readEntity(returnType);
+    }
 
-				ActionResponse ar = ResponseToActionResponse.INSTANCE.apply(handle.getResponse());
-				if (handle.getReturnType() == ActionResponse.class)
-					return handle.complete((T) ar);
+    private static <T> Handle<T> handle404(Handle<T> handle) {
+        if (handle.getResponse().getStatus() == 404) {
 
-				throw mapException(ar.getFault(), handle.getResponse().getStatus());
-			}
-			catch (ResponseException re) {
-				throw re;
-			}
-			catch (Exception e) {
-				e.printStackTrace();
-			}
-			finally {
-				closeQuietly(handle.getResponse());
-			}
-		}
-		return handle.continueHandling();
-	}
+            if (ListType.class.isAssignableFrom(handle.getReturnType())) {
+                try {
+                    return handle.complete(handle.getReturnType().newInstance());
+                } catch (InstantiationException e) {
+                    e.printStackTrace();
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                } finally {
+                    closeQuietly(handle.getResponse());
+                }
+            }
 
-	private static void closeQuietly(HttpResponse response) {
-		try {
-			response.close();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+            if (handle.getReturnType() != ActionResponse.class) {
+                closeQuietly(handle.getResponse());
+                return handle.complete(null);
+            }
+        }
+
+        return handle.continueHandling();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Handle<T> handleLessThan500(Handle<T> handle) {
+        if (handle.getResponse().getStatus() < 500) {
+            try {
+                ActionResponse ar = ResponseToActionResponse.INSTANCE.apply(handle.getResponse());
+                if (handle.getReturnType() == ActionResponse.class) {
+                    return handle.complete((T) ar);
+                }
+                throw mapException(ar.getFault(), handle.getResponse().getStatus());
+            } catch (ResponseException re) {
+                throw re;
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                closeQuietly(handle.getResponse());
+            }
+        }
+        return handle.continueHandling();
+    }
+
+    private static void closeQuietly(HttpResponse response) {
+        try {
+            response.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }


### PR DESCRIPTION
… or Void.class when using HttpClient

As the response content is not read, the connection is not automatically closed: explicitly add a close call.

Fix file indentation

Issue #360