### PR TITLE
endpoint resolution for Keystone V3 catalog services now includes region

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/AccessWrapper.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/AccessWrapper.java
@@ -1,5 +1,6 @@
 package org.openstack4j.openstack.identity.domain.v3;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,7 +55,13 @@ public class AccessWrapper implements Access {
 	 */
 	@Override
 	public List<? extends Service> getServiceCatalog() {
-		return null;
+		List<? extends Catalog> catalogs = this.token.getCatalog();
+		List<Service> services = new ArrayList<Service>(catalogs.size());
+		for (Catalog catalog : catalogs) {
+			Service wrappedCatalog = ServiceWrapper.wrap(catalog);
+			services.add(wrappedCatalog);
+		}
+		return services;
 	}
 
 	/**


### PR DESCRIPTION
The patch submitted in this pull requests fixes an issue I discovered with openstack4j when used in a multi-regional OpenStack deployment.

More specifically, the code in its current state does not include the region specified via OSClient.useRegion() when matching endpoints from a  Keystone V3 service catalog (I'm not sure if the same issue exists when using Keystone version 2). 

The proposed patch makes sure that the DefaultEndpointURLResolver selects a service endpoint from the right region (if a region has been specified in the URLResolverParams).