### PR TITLE
Add support for RAX API key authentication extension

### DIFF
--- a/core/src/main/java/org/openstack4j/api/client/IOSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/api/client/IOSClientBuilder.java
@@ -96,6 +96,14 @@ public interface IOSClientBuilder<R, T extends IOSClientBuilder<R, T>> {
         V2 tenantId(String tenantId);
         
         /**
+         * Use Rackspace API Key Authentication Admin Extension to authenticate
+         * 
+         * @param raxApiKey true if enabled
+         * @return self for method chaining
+         */
+        V2 raxApiKey(boolean raxApiKey);
+        
+        /**
          * Allows authentication via an existing Token versus {@link #credentials(String, String)}.  Note:  The 
          * {@link #tenantId(String)} or {@link #tenantName(String)} will required when using this method for
          * authentication.

--- a/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
+++ b/core/src/main/java/org/openstack4j/openstack/client/OSClientBuilder.java
@@ -9,6 +9,7 @@ import org.openstack4j.api.types.Facing;
 import org.openstack4j.core.transport.Config;
 import org.openstack4j.model.common.Identifier;
 import org.openstack4j.openstack.identity.domain.Credentials;
+import org.openstack4j.openstack.identity.domain.RaxApiKeyCredentials;
 import org.openstack4j.openstack.identity.domain.TokenAuth;
 import org.openstack4j.openstack.identity.domain.v3.KeystoneAuth;
 import org.openstack4j.openstack.identity.domain.v3.KeystoneAuth.AuthScope;
@@ -72,6 +73,7 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
         String tenantName;
         String tenantId;
         String tokenId;
+        boolean raxApiKey;
         
         @Override
         public ClientV2 tenantName(String tenantName) {
@@ -86,10 +88,20 @@ public abstract class OSClientBuilder<R, T extends IOSClientBuilder<R, T>> imple
         }
         
         @Override
+        public ClientV2 raxApiKey(boolean raxApiKey) {
+            this.raxApiKey = raxApiKey;
+            return this;
+        }
+        
+        @Override
         public OSClient authenticate() throws AuthenticationException {
             if (tokenId != null) {
                 checkArgument(tenantName != null || tenantId != null, "TenantId or TenantName is required when using Token Auth");
                 return OSAuthenticator.invoke(new TokenAuth(tokenId, tenantName, tenantId), endpoint, perspective, config);
+            }
+            
+            if (raxApiKey) {
+                return OSAuthenticator.invoke(new RaxApiKeyCredentials(user, password), endpoint, perspective, config);
             }
             
             return OSAuthenticator.invoke(new Credentials(user, password, tenantName, tenantId), endpoint, perspective, config);

--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/Auth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/Auth.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public abstract class Auth implements ModelEntity {
 
 	private static final long serialVersionUID = 1L;
-	public enum Type { CREDENTIALS, TOKEN };
+	public enum Type { CREDENTIALS, TOKEN, RAX_APIKEY };
 	
 	private String tenantId;
 	private String tenantName;

--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/RaxApiKeyCredentials.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/RaxApiKeyCredentials.java
@@ -1,0 +1,94 @@
+package org.openstack4j.openstack.identity.domain;
+
+import org.openstack4j.model.identity.AuthStore;
+import org.openstack4j.model.identity.AuthVersion;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+@JsonRootName("auth")
+public class RaxApiKeyCredentials extends Auth implements AuthStore {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("RAX-KSKEY:apiKeyCredentials")
+    private ApiKeyCredentials apikeyCreds = new ApiKeyCredentials();
+
+
+    public RaxApiKeyCredentials() {
+        super(Type.RAX_APIKEY);
+    }
+
+    public RaxApiKeyCredentials(String username, String apiKey) {
+        this();
+        apikeyCreds.setCredentials(username, apiKey);
+    }
+
+    @Override
+    @JsonIgnore
+	public String getTenantId() {
+        return super.getTenantId();
+	}
+
+    @Override
+    @JsonIgnore
+	public String getTenantName() {
+        return super.getTenantName();
+	}
+
+    @JsonIgnore
+    public String getUsername() {
+        return apikeyCreds.username;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getPassword() {
+        return getApiKey();
+    }
+
+    @JsonIgnore
+    public String getApiKey() {
+        return apikeyCreds.apiKey;
+    }
+
+    @SuppressWarnings("unchecked")
+    @JsonIgnore
+    @Override
+    public <T> T unwrap() {
+        return (T) this;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getId() {
+        return getTenantId();
+    }
+
+    @JsonIgnore
+    @Override
+    public String getName() {
+        return getTenantName();
+    }
+
+    private static final class ApiKeyCredentials {
+
+        @JsonProperty
+        String username;
+        @JsonProperty
+        String apiKey;
+
+        public void setCredentials(String username, String apiKey) {
+            this.username = username;
+            this.apiKey = apiKey;
+        }
+    }
+
+
+    @JsonIgnore
+    @Override
+    public AuthVersion getVersion() {
+        return AuthVersion.V2;
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
@@ -16,6 +16,7 @@ import org.openstack4j.model.identity.AuthVersion;
 import org.openstack4j.openstack.identity.domain.Auth;
 import org.openstack4j.openstack.identity.domain.Auth.Type;
 import org.openstack4j.openstack.identity.domain.Credentials;
+import org.openstack4j.openstack.identity.domain.RaxApiKeyCredentials;
 import org.openstack4j.openstack.identity.domain.KeystoneAccess;
 import org.openstack4j.openstack.identity.domain.TokenAuth;
 import org.openstack4j.openstack.identity.domain.v3.AccessWrapper;
@@ -44,7 +45,7 @@ public class OSAuthenticator {
      */
     public static OSClient invoke(AuthStore auth, String endpoint, Facing perspective, Config config) {
         if (auth.getVersion() == AuthVersion.V2)
-            return authenticateV2((Credentials) auth.unwrap(), endpoint, perspective, false, config);
+            return authenticateV2((Auth) auth.unwrap(), endpoint, perspective, false, config);
 
         return authenticateV3((KeystoneAuth) auth.unwrap(), endpoint, perspective, config);
     }
@@ -107,6 +108,9 @@ public class OSAuthenticator {
         
         if (auth.getType() == Type.CREDENTIALS) {
             access = access.applyContext(endpoint, (Credentials) auth);
+        }
+        else if (auth.getType() == Type.RAX_APIKEY) {
+            access = access.applyContext(endpoint, (RaxApiKeyCredentials) auth);
         }
         else {
             access = access.applyContext(endpoint, (TokenAuth) auth);


### PR DESCRIPTION
Rackspace supports API-key based authentication mechanism documented at
http://docs.rackspace.com/files/api/v1/cf-devguide/content/Retrieving_Auth_Token.html
and http://docs.rackspace.com/openstack-extensions/auth/RAX-KSKEY-admin-devguide/content/RackExt-0001.html.

We can use API key instead of password + tenantName with this mechanism.

This is useful especially when we want to improve security using multi-factor
authentication because password-based authentication fails if
multi-factor authentication is enabled.

We can use this extension with this code:

```java
client = OSFactory.builder()
    .endpoint("https://identity.api.rackspacecloud.com/v2.0")
    .credentials("myuser", "mayapikey")
    .raxApiKey(true)
    .authenticate()
client.objectStorage().objects().list("mycontainer")
```

I implemented it as a part of V2 authentication because it's an extension of authentication V2.