### PR TITLE
Add query parameters to delete and put options for large objects

### DIFF
--- a/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
@@ -11,6 +11,7 @@ import org.openstack4j.model.storage.block.options.DownloadOptions;
 import org.openstack4j.model.storage.object.SwiftObject;
 import org.openstack4j.model.storage.object.options.ObjectListOptions;
 import org.openstack4j.model.storage.object.options.ObjectLocation;
+import org.openstack4j.model.storage.object.options.ObjectDeleteOptions;
 import org.openstack4j.model.storage.object.options.ObjectPutOptions;
 
 /**
@@ -120,6 +121,15 @@ public interface ObjectStorageObjectService extends RestService {
      * @return the action response
      */
     ActionResponse delete(ObjectLocation location);
+    
+    /**
+     * Deletes an Object from the specified container
+     * 
+     * @param location location containing container name and object name
+     * @param options the deleting options
+     * @return the action response
+     */
+    ActionResponse delete(ObjectLocation location, ObjectDeleteOptions options);
     
     /**
      * Copies an object to another object in the object store

--- a/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectDeleteOptions.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectDeleteOptions.java
@@ -1,0 +1,42 @@
+package org.openstack4j.model.storage.object.options;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+/**
+ * Options used for the deletion of Objects
+ */
+public final class ObjectDeleteOptions {
+
+    public static final ObjectDeleteOptions NONE = new ObjectDeleteOptions();
+
+    private Map<String, List<Object>> queryParams = Maps.newHashMap();
+
+    private ObjectDeleteOptions() { }
+
+    public static ObjectDeleteOptions create() {
+        return new ObjectDeleteOptions();
+    }
+
+    public ObjectDeleteOptions queryParam(String key, Object value) {
+        if (value == null)
+            return this;
+
+        if (queryParams.containsKey(key)) {
+            List<Object> list = queryParams.get(key);
+            list.add(value);
+        } else {
+            List<Object> list = new ArrayList<Object>();
+            list.add(value);
+            queryParams.put(key, list);
+        }
+        return this;
+    }
+
+    public Map<String, List<Object>> getQueryParams() {
+        return queryParams;
+    }
+}

--- a/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectPutOptions.java
+++ b/core/src/main/java/org/openstack4j/model/storage/object/options/ObjectPutOptions.java
@@ -3,6 +3,8 @@ package org.openstack4j.model.storage.object.options;
 import static org.openstack4j.model.storage.object.SwiftHeaders.OBJECT_METADATA_PREFIX;
 import static org.openstack4j.model.storage.object.SwiftHeaders.CONTENT_TYPE;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.openstack.storage.object.functions.MetadataToHeadersFunction;
@@ -18,6 +20,7 @@ public final class ObjectPutOptions {
 
     public static final ObjectPutOptions NONE = new ObjectPutOptions();
     Map<String, String> headers = Maps.newHashMap();
+    private Map<String, List<Object>> queryParams = Maps.newHashMap();
     private String path;
     
     private ObjectPutOptions() { }
@@ -64,5 +67,24 @@ public final class ObjectPutOptions {
     
     public String getPath() {
         return path;
+    }
+    
+    public ObjectPutOptions queryParam(String key, Object value) {
+        if (value == null)
+            return this;
+
+        if (queryParams.containsKey(key)) {
+            List<Object> list = queryParams.get(key);
+            list.add(value);
+        } else {
+            List<Object> list = new ArrayList<Object>();
+            list.add(value);
+            queryParams.put(key, list);
+        }
+        return this;
+    }
+    
+    public Map<String, List<Object>> getQueryParams() {
+        return queryParams;
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -122,6 +122,15 @@ public class BaseOpenStackService {
             return this;
         }
 
+        public Invocation<R> paramLists(Map<String, ? extends Iterable<? extends Object>> params) {
+            if (params != null) {
+                for (Map.Entry<String, ? extends Iterable<? extends Object>> pair : params.entrySet())
+                    for (Object value : pair.getValue())
+                        req.queryParam(pair.getKey(), value);
+            }
+            return this;
+        }
+
         public Invocation<R> serviceType(ServiceType serviceType) {
             req.serviceType(serviceType);
             return this;

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -21,6 +21,7 @@ import org.openstack4j.model.storage.block.options.DownloadOptions;
 import org.openstack4j.model.storage.object.SwiftObject;
 import org.openstack4j.model.storage.object.options.ObjectListOptions;
 import org.openstack4j.model.storage.object.options.ObjectLocation;
+import org.openstack4j.model.storage.object.options.ObjectDeleteOptions;
 import org.openstack4j.model.storage.object.options.ObjectPutOptions;
 import org.openstack4j.openstack.common.DLPayloadEntity;
 import org.openstack4j.openstack.common.functions.HeaderNameValuesToHeaderMap;
@@ -126,6 +127,7 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
                               .entity(payload)
                               .headers(options.getOptions())
                               .contentType(options.getContentType())
+                              .paramLists(options.getQueryParams())
                               .executeWithResponse();
         try
         {
@@ -146,8 +148,16 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
 
     @Override
     public ActionResponse delete(ObjectLocation location) {
+        return delete(location, ObjectDeleteOptions.NONE);
+    }
+
+    @Override
+    public ActionResponse delete(ObjectLocation location, ObjectDeleteOptions options) {
         checkNotNull(location);
-        return deleteWithResponse(location.getURI()).execute();
+        checkNotNull(options);
+        return delete(ActionResponse.class, location.getURI())
+            .paramLists(options.getQueryParams())
+            .execute();
     }
     
     /**


### PR DESCRIPTION
This change adds primitive support for large objects of Swift.
Large objects are documented at http://docs.openstack.org/developer/swift/api/large_objects.html.

For example, with JRuby, we can use the additional APIs as following:

```ruby
require 'json'
import "java.io.ByteArrayInputStream"
import "org.openstack4j.openstack.OSFactory"
import "org.openstack4j.model.storage.object.options.ObjectLocation"
import "org.openstack4j.model.storage.object.options.ObjectPutOptions"
import "org.openstack4j.model.storage.object.options.ObjectDeleteOptions"
import "org.openstack4j.model.common.Payloads"

client = OSFactory.builder()...authenticate()

# Upload 2 files.
# Each segment excepting the final segment must be larger than 1MB.
data1 = "segment1" * (1024 * 1024 * 5)
data2 = "segment2" * (1024 * 1024 * 5)

etag1 = client.objectStorage().objects().put(
  "mycontainer", "segment1",
  Payloads.create(ByteArrayInputStream.new(data1.to_java.getBytes)))

etag2 = client.objectStorage().objects().put(
  "mycontainer", "segment2",
  Payloads.create(ByteArrayInputStream.new(data2.to_java.getBytes)))

# Upload manifest file with ?multipart-manifest=put query parameter.
manifest = [
  {
    path: "mycontainer/segment1",
    etag: etag1,
    size_bytes: data1.size
  },
  {
    path: "mycontainer/segment2",
    etag: etag2,
    size_bytes: data2.size
  },
].to_json

client.objectStorage().objects().put(
  "mycontainer", "large_file",
  Payloads.create(ByteArrayInputStream.new(manifest.to_java.getBytes)),
  ObjectPutOptions.create().queryParam("multipart-manifest", "put"))

# Downloading large_file resuls returns concatenated contents of segments.
client.objectStorage().objects().get("mycontainer", "large_file").download().getInputStream()

# Deleting large_file with ?multipart-manifest=delete query parameter deletes all segments as well as large_file.
client.objectStorage().objects().delete(
  ObjectLocation.create("mycontainer", "large_file"),
  ObjectDeleteOptions.create().queryParam("multipart-manifest", "delete"))
```
