### PR TITLE
Fix OSAuthenticator. authenticateV3 (Fixes #444, #446)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ notifications:
 branches:
   only:
     - master
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ notifications:
 branches:
   only:
     - master
-    

--- a/core/src/main/java/org/openstack4j/model/common/DLPayload.java
+++ b/core/src/main/java/org/openstack4j/model/common/DLPayload.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.openstack4j.core.transport.HttpResponse;
+
 /**
  * A Payload which encapsulates downstream data
  * 
@@ -11,6 +13,13 @@ import java.io.InputStream;
  */
 public interface DLPayload {
 
+    /**
+     * The HttpResponse
+     * 
+     * @return the HttpResponse
+     */
+	HttpResponse getHttpResponse();
+	
     /**
      * The raw inputstream
      * 

--- a/core/src/main/java/org/openstack4j/openstack/common/DLPayloadEntity.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/DLPayloadEntity.java
@@ -7,6 +7,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.model.common.DLPayload;
 
 import com.google.common.io.ByteStreams;
@@ -18,26 +19,31 @@ import com.google.common.io.ByteStreams;
  */
 public class DLPayloadEntity implements DLPayload {
 
-    private final InputStream stream;
+    private final HttpResponse response;
 
-    private DLPayloadEntity(InputStream stream) {
-        this.stream = stream;
+    private DLPayloadEntity(HttpResponse response) {
+        this.response = response;
     }
 
-    public static DLPayloadEntity create(InputStream stream) {
-        return new DLPayloadEntity(stream);
+    public static DLPayloadEntity create(HttpResponse response) {
+        return new DLPayloadEntity(response);
     }
 
+	@Override
+	public HttpResponse getHttpResponse() {
+		return response;
+	}
+	
     @Override
     public InputStream getInputStream() {
-        return stream;
+        return response.getInputStream();
     }
 
     @Override
     public void writeToFile(File file) throws IOException {
         checkNotNull(file);
 
-        ByteStreams.copy(stream, new FileOutputStream(file));
+        ByteStreams.copy(response.getInputStream(), new FileOutputStream(file));
     }
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -235,7 +235,6 @@ public class ObjectStorageObjectServiceImpl extends BaseObjectStorageService imp
                   get(Void.class, location.getURI())
                     .headers(HeaderNameValuesToHeaderMap.INSTANCE.apply(options.getHeaders()))
                     .executeWithResponse()
-                    .getInputStream()
                );
     }
 }


### PR DESCRIPTION
Issue: https://github.com/gondor/openstack4j/issues/444

The user’s OSClient object becomes out of scope during reauthentication because authenticateV3 does not update the OSClient object. Instead it returns a new OSClient object which is never passed back to the user during reauthentication. The user is left with the out of scope OSClient object and that OSClient's access is outdated. This becomes very problematic in multi-threaded applications.

OSAuthenticator.authenticateV2 handles it properly.

Issue: https://github.com/gondor/openstack4j/issues/446

Currently, if getting an object is not successful, the user does not
know whether the GET was successful or not.  For example, if the result
is a 404, then reading from the InputStream will result in the stream
containing the message saying data not available instead of the data
that is actually wanted.

Steps to reproduce:
Try to download a file that does not exist. Reading the input stream

Proposed solution:
Allow users to check the response to see whether the request is
successful or not before reading form the input stream.

Author: Sajid Nasir
Date: 9/8/2015
Affected files: 
OSAuthenticator.java, DLPayload.java, DLPayloadEntity.java, ObjectStorageObjectServiceImpl.java
