### PR TITLE
Correction nested template

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/heat/utils/Template.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/utils/Template.java
@@ -68,11 +68,12 @@ public class Template {
                 //Processing the nested template
                 if(isTemplate(skey, valueInString)) {
                     try {
-                        URL templateName =  TemplateUtils.normaliseFilePathToUrl(baseUrl + valueInString);
+                        final String templateName = valueInString;
+                    	final URL fullTemplateName =  TemplateUtils.normaliseFilePathToUrl(baseUrl + templateName);
 
-                        if(! files.containsKey(templateName.toString())) {
-                            Template tpl = new Template(templateName);
-                            files.put(templateName.toString(),tpl.getTplContent());
+                        if(! files.containsKey(templateName)) {
+                            final Template tpl = new Template(fullTemplateName);
+                            files.put(templateName, tpl.getTplContent());
                             files.putAll(tpl.getFiles());
                         }
                     } catch (URISyntaxException e) {


### PR DESCRIPTION
Hi,

I change the name of the template push to the files map. In fact if the name is relative, the mapping between the master template and the sub template doesn't match because the name isn't found in the map because it became an absolute name.

Bests regards.