### PR TITLE
Fixing NPE from v3 reauths (Fixes #459)

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
@@ -152,7 +152,7 @@ public class OSAuthenticator {
         	return OSClientSession.createSession(AccessWrapper.wrap(access.applyContext(endpoint, credentials)), perspective, config);
         
         OSClientSession current = OSClientSession.getCurrent();
-        current.access = AccessWrapper.wrap(access);
+        current.access = AccessWrapper.wrap(access.applyContext(endpoint, credentials));
         return current;
 
     }


### PR DESCRIPTION
Fix for issue: https://github.com/gondor/openstack4j/issues/459

If the client tries to reauthenticate more than once from an expired
token, after the first time, all future reauthentications will fail
because of NPE.

Steps to reproduce:
Let client reauthenticate more than once.

Proposed solution:
Provide the endpoint and credentials to the access object during
reauthentication.

Author: Sajid Nasir
Date: 9/22/2015
Affected files:
OSAuthenticator.java,