### PR TITLE
Do not throw Exceptions in static initializer

### DIFF
--- a/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
+++ b/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
@@ -12,7 +12,7 @@ import org.openstack4j.openstack.logging.LoggerFactory;
 
 /**
  * HttpExecutor is a delegate to the underline connector associated to OpenStack4j.
- * 
+ *
  * @author Jeremy Unruh
  */
 public class HttpExecutor  {
@@ -21,33 +21,33 @@ public class HttpExecutor  {
     private static final HttpExecutor INSTANCE = new HttpExecutor();
     private HttpExecutorService service;
 
-    private HttpExecutor() { 
-        initService();
-    }
+    private HttpExecutor() {}
 
-    private void initService() {
+    private HttpExecutorService service() {
+        if (service != null) return service;
+
         Iterator<HttpExecutorService> it = ServiceLoader.load(HttpExecutorService.class, getClass().getClassLoader()).iterator();
         if (!it.hasNext())
         {
             LOG.error("No OpenStack4j connector found in classpath");
             throw new ConnectorNotFoundException("No OpenStack4j connector found in classpath");
         }
-        service = it.next();
+        return service = it.next();
     }
 
     public static HttpExecutor create() {
         return INSTANCE;
     }
-    
+
     public String getExecutorName() {
-        return service.getExecutorDisplayName();
+        return service().getExecutorDisplayName();
     }
 
     /**
-     * Delegate to {@link HttpExecutorService#execute(HttpRequest)} 
+     * Delegate to {@link HttpExecutorService#execute(HttpRequest)}
      */
     public <R> HttpResponse execute(HttpRequest<R> request) {
         LOG.debug("Executing Request: %s -> %s", request.getEndpoint(), request.getPath());
-        return service.execute(request);
+        return service().execute(request);
     }
 }


### PR DESCRIPTION
When openstack4j fails to load `HttpExecutorService` implementation it throws an exception while initializing class (static field `HttpExecutor.INSTANCE` -> constructor -> `throw`). The real cause is wrapped in unhelpful exception:

```
java.lang.NoClassDefFoundError: Could not initialize class org.openstack4j.core.transport.internal.HttpExecutor
	at org.openstack4j.openstack.internal.OSAuthenticator.authenticateV2(OSAuthenticator.java:97)
	at org.openstack4j.openstack.internal.OSAuthenticator.invoke(OSAuthenticator.java:48)
	at org.openstack4j.openstack.client.OSClientBuilder$ClientV2.authenticate(OSClientBuilder.java:107)
	at org.openstack4j.openstack.client.OSClientBuilder$ClientV2.authenticate(OSClientBuilder.java:71)
```

This is what user get after the fix:

```
org.openstack4j.api.exceptions.ConnectorNotFoundException: No OpenStack4j connector found in classpath
	at org.openstack4j.core.transport.internal.HttpExecutor.service(HttpExecutor.java:31)
	at org.openstack4j.core.transport.internal.HttpExecutor.execute(HttpExecutor.java:49)
	at org.openstack4j.openstack.internal.OSAuthenticator.authenticateV2(OSAuthenticator.java:97)
	at org.openstack4j.openstack.internal.OSAuthenticator.invoke(OSAuthenticator.java:48)
	at org.openstack4j.openstack.client.OSClientBuilder$ClientV2.authenticate(OSClientBuilder.java:107)
	at org.openstack4j.openstack.client.OSClientBuilder$ClientV2.authenticate(OSClientBuilder.java:71)
```