### PR TITLE
Kill context classloader

### DIFF
--- a/core/src/main/java/org/openstack4j/api/Apis.java
+++ b/core/src/main/java/org/openstack4j/api/Apis.java
@@ -82,7 +82,7 @@ public class Apis {
 	}
 	
 	private static APIProvider initializeProvider() {
-		APIProvider p = ServiceLoader.load(APIProvider.class).iterator().next();
+		APIProvider p = ServiceLoader.load(APIProvider.class, Apis.class.getClassLoader()).iterator().next();
 		p.initialize();
 		return p;
 	}

--- a/core/src/main/java/org/openstack4j/api/Apis.java
+++ b/core/src/main/java/org/openstack4j/api/Apis.java
@@ -82,6 +82,7 @@ public class Apis {
 	}
 	
 	private static APIProvider initializeProvider() {
+		// No need to check for emptiness as there is default implementation registered
 		APIProvider p = ServiceLoader.load(APIProvider.class, Apis.class.getClassLoader()).iterator().next();
 		p.initialize();
 		return p;

--- a/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
+++ b/core/src/main/java/org/openstack4j/core/transport/internal/HttpExecutor.java
@@ -26,7 +26,7 @@ public class HttpExecutor  {
     }
 
     private void initService() {
-        Iterator<HttpExecutorService> it = ServiceLoader.load(HttpExecutorService.class).iterator();
+        Iterator<HttpExecutorService> it = ServiceLoader.load(HttpExecutorService.class, getClass().getClassLoader()).iterator();
         if (!it.hasNext())
         {
             LOG.error("No OpenStack4j connector found in classpath");

--- a/core/src/main/java/org/openstack4j/openstack/logging/LoggerFactory.java
+++ b/core/src/main/java/org/openstack4j/openstack/logging/LoggerFactory.java
@@ -22,7 +22,7 @@ public class LoggerFactory {
     }
 
     private static LoggerFactorySupplier getSupplier() {
-        Iterator<LoggerFactorySupplier> it = ServiceLoader.load(LoggerFactorySupplier.class).iterator();
+        Iterator<LoggerFactorySupplier> it = ServiceLoader.load(LoggerFactorySupplier.class, LoggerFactory.class.getClassLoader()).iterator();
         if (it != null && it.hasNext())
             return it.next();
         

--- a/core/src/main/java/org/openstack4j/openstack/logging/LoggerFactory.java
+++ b/core/src/main/java/org/openstack4j/openstack/logging/LoggerFactory.java
@@ -23,10 +23,9 @@ public class LoggerFactory {
 
     private static LoggerFactorySupplier getSupplier() {
         Iterator<LoggerFactorySupplier> it = ServiceLoader.load(LoggerFactorySupplier.class, LoggerFactory.class.getClassLoader()).iterator();
-        if (it != null && it.hasNext())
+        if (it.hasNext())
             return it.next();
         
         return FallbackLoggerFactorySupplier.getInstance();
     }
-    
 }


### PR DESCRIPTION
`ServiceLoader.load(Class)` relies on context class loader by default. As openstack4j does not provide any, this effectively delegates the responsibility for resetting context classloaders with each call that looks up extensions (which is a process that should be encapsulated) to the client.

I am using openstack4j in environment where context classloaders can not load necessary classes so without this fix, I have to wrap the calls into:

```java
        final Thread thread = Thread.currentThread();
        final ClassLoader oldLoader = thread.getContextClassLoader();
        thread.setContextClassLoader(getClass().getClassLoader());
        try {
            // Now use the convenient openstack4j DSL
        } finally {
            thread.setContextClassLoader(oldLoader);
        }
```

I suggest to rely on whatever classloader loaded openstack4j classes. If this turns out to be necessary to configure, clean API for providing classloades should be created.

Without this fix I am getting exceptions like:
```
java.lang.NoClassDefFoundError: Could not initialize class org.openstack4j.api.Apis
	at org.openstack4j.openstack.internal.OSClientSession.networking(OSClientSession.java:260)
```

CC #466