### PR TITLE
domain scoped authentication with tests

### DIFF
--- a/core-test/src/main/resources/identity.v3/authv3_domainId_userId.json
+++ b/core-test/src/main/resources/identity.v3/authv3_domainId_userId.json
@@ -1,0 +1,101 @@
+{
+"token": {
+	"domain": {
+		"id": "default", 
+		"name": "Default"
+	}, 
+	"methods": ["password"], 
+	"roles": [{
+		"id": "6ead57f8ae124996af8b0beb72ff1007", 
+		"name": "admin"
+		}], 
+	"expires_at": "2015-08-26T14:14:09.200971Z", 
+	"catalog": [
+		{
+		"endpoints":[{
+			"region_id": "RegionOne", 
+			"url": "http://devstack.openstack.stack:9292", 
+			"region": "RegionOne", 
+			"interface": "public", 
+			"id": "6e82c8912d3f49a09df51035681d564c"
+			},
+        	{
+        	"region_id": "RegionOne", 
+        	"url": "http://devstack.openstack.stack:9292", 
+        	"region": "RegionOne", 
+        	"interface": "admin", 
+        	"id": "7e44d321ae80457abc3728fa1e6feb32"
+        	},
+        	{
+        	"region_id": "RegionOne", 
+        	"url": "http://devstack.openstack.stack:9292", 
+        	"region": "RegionOne", 
+        	"interface": "internal", 
+        	"id": "c9a090a4597040849c03bc13588167f6"
+        	}],
+        	"type": "image", 
+        	"id": "0d56500210a24c38a3702b6825e24164", 
+        	"name": "glance"
+        	},
+        {
+        "endpoints": [], 
+        "type": "volumev2", 
+        "id": "2b92e79c45254516932c633229cd0e8b",
+        "name": "cinderv2"
+        	}, 
+        {
+        "endpoints": [
+        	{
+        	"region_id": "RegionOne", 
+        	"url": "http://devstack.openstack.stack:8773/",
+        	"region": "RegionOne", 
+        	"interface": "admin", 
+        	"id": "1ce26a6fffd0424bac135b9c68055b6e"
+        	},
+        	{
+        	"region_id": "RegionOne", 
+        	"url": "http://devstack.openstack.stack:8773/", 
+        	"region": "RegionOne", 
+        	"interface": "public", 
+        	"id": "98db699b9ffa4dffb027d78163aad8cc"
+        	},
+        	{
+        	"region_id": "RegionOne", 
+        	"url": "http://devstack.openstack.stack:8773/", 
+        	"region": "RegionOne", 
+        	"interface": "internal", 
+        	"id": "ece52860cf1e4eb6a8fed05c47a30147"
+        	}],
+        	"type": "ec2", 
+        	"id": "3364a7b95c664bf89a7a8db081576364", 
+        	"name": "ec2"
+        	}, 
+        {
+        "endpoints":
+        [], "type": "volume", "id": "511b94ce0482484ea09028091dd5e9a5", "name": "cinder"},
+        {"endpoints": [], "type": "compute", "id": "5b7028751ed045d79467c7845ecb8c58",
+        "name": "nova"}, {"endpoints": [], "type": "computev21", "id": "97e665cbada043718180c5a6316df76a",
+        "name": "novav21"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3",
+        "region": "RegionOne", "interface": "admin", "id": "185eda94de9340e58245062f75d7f80e"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "internal", "id": "9abd6797844d455f875af9537325cba4"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "public", "id": "d3b31f24e4ea40699f731e29e625c187"}],
+        "type": "identity", "id": "b577d8f7c7074d04a1165fcca638b600", "name": "keystone_v3x"},
+        {"endpoints": [{"region_id": "europe", "url": "http://devstack.openstack.stack:35357/v3",
+        "region": "europe", "interface": "admin", "id": "32bb2c6aea944ea6b4956eb24142d2e2"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "public", "id": "480ea71dc8cf4c959df1c6304be87056"},
+        {"region_id": "europe", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "europe", "interface": "public", "id": "600638643d22494fad4f30e3b22ae124"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "internal", "id": "8a254651925e4a3e9505c863a00c017e"},
+        {"region_id": "europe", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "europe", "interface": "internal", "id": "b93da6aaba654d8cb451ff8378d7d2a5"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3", "region":
+        "RegionOne", "interface": "admin", "id": "d5f8e0da0f3345529a5fb324d735d4a3"}],
+        "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009", "name": "keystone_v3"}],
+        "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
+        "aa9f25defa6d4cafb48466df83106065", "name": "admin"}, "audit_ids": ["gdkPX0P8RfChxa18M4Y2Tg"],
+        "issued_at": "2015-08-26T13:14:09.201023Z"}
+}

--- a/core-test/src/main/resources/identity.v3/authv3_domainId_userName.json
+++ b/core-test/src/main/resources/identity.v3/authv3_domainId_userName.json
@@ -1,0 +1,46 @@
+{
+"token": {"domain": {"id": "default", "name": "Default"}, "methods":
+        ["password"], "roles": [{"id": "6ead57f8ae124996af8b0beb72ff1007", "name":
+        "admin"}], "expires_at": "2015-08-26T14:14:09.335998Z", "catalog": [{"endpoints":
+        [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region":
+        "RegionOne", "interface": "public", "id": "6e82c8912d3f49a09df51035681d564c"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region":
+        "RegionOne", "interface": "admin", "id": "7e44d321ae80457abc3728fa1e6feb32"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region":
+        "RegionOne", "interface": "internal", "id": "c9a090a4597040849c03bc13588167f6"}],
+        "type": "image", "id": "0d56500210a24c38a3702b6825e24164", "name": "glance"},
+        {"endpoints": [], "type": "volumev2", "id": "2b92e79c45254516932c633229cd0e8b",
+        "name": "cinderv2"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8773/",
+        "region": "RegionOne", "interface": "admin", "id": "1ce26a6fffd0424bac135b9c68055b6e"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8773/", "region":
+        "RegionOne", "interface": "public", "id": "98db699b9ffa4dffb027d78163aad8cc"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8773/", "region":
+        "RegionOne", "interface": "internal", "id": "ece52860cf1e4eb6a8fed05c47a30147"}],
+        "type": "ec2", "id": "3364a7b95c664bf89a7a8db081576364", "name": "ec2"}, {"endpoints":
+        [], "type": "volume", "id": "511b94ce0482484ea09028091dd5e9a5", "name": "cinder"},
+        {"endpoints": [], "type": "compute", "id": "5b7028751ed045d79467c7845ecb8c58",
+        "name": "nova"}, {"endpoints": [], "type": "computev21", "id": "97e665cbada043718180c5a6316df76a",
+        "name": "novav21"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3",
+        "region": "RegionOne", "interface": "admin", "id": "185eda94de9340e58245062f75d7f80e"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "internal", "id": "9abd6797844d455f875af9537325cba4"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "public", "id": "d3b31f24e4ea40699f731e29e625c187"}],
+        "type": "identity", "id": "b577d8f7c7074d04a1165fcca638b600", "name": "keystone_v3x"},
+        {"endpoints": [{"region_id": "europe", "url": "http://devstack.openstack.stack:35357/v3",
+        "region": "europe", "interface": "admin", "id": "32bb2c6aea944ea6b4956eb24142d2e2"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "public", "id": "480ea71dc8cf4c959df1c6304be87056"},
+        {"region_id": "europe", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "europe", "interface": "public", "id": "600638643d22494fad4f30e3b22ae124"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "RegionOne", "interface": "internal", "id": "8a254651925e4a3e9505c863a00c017e"},
+        {"region_id": "europe", "url": "http://devstack.openstack.stack:5000/v3", "region":
+        "europe", "interface": "internal", "id": "b93da6aaba654d8cb451ff8378d7d2a5"},
+        {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3", "region":
+        "RegionOne", "interface": "admin", "id": "d5f8e0da0f3345529a5fb324d735d4a3"}],
+        "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009", "name": "keystone_v3"}],
+        "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
+        "aa9f25defa6d4cafb48466df83106065", "name": "admin"}, "audit_ids": ["m5vsr2xgRuKNQezeN78VAw"],
+        "issued_at": "2015-08-26T13:14:09.336033Z"}
+}

--- a/core-test/src/main/resources/identity.v3/authv3_domainName_userId.json
+++ b/core-test/src/main/resources/identity.v3/authv3_domainName_userId.json
@@ -1,0 +1,262 @@
+{
+	"token": {
+		"domain": {
+			"id": "default",
+			"name": "Default"
+		},
+		"methods": ["password"],
+		"roles": [{
+			"id": "6ead57f8ae124996af8b0beb72ff1007",
+			"name": "admin"
+		}],
+		"expires_at": "2015-08-26T14:14:09.416956Z",
+		"catalog": [{
+			"endpoints": [
+			{
+				"region_id": "RegionOne", 
+				"url":"http://devstack.openstack.stack:9292", 
+				"region": "RegionOne", 
+				"interface": "public",
+        		"id": "6e82c8912d3f49a09df51035681d564c"
+        		}, 
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:9292", 
+        		"region": "RegionOne", 
+        		"interface": "admin",
+        		"id": "7e44d321ae80457abc3728fa1e6feb32"
+        		}, 
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:9292", 
+        		"region": "RegionOne", 
+        		"interface": "internal",
+        		"id": "c9a090a4597040849c03bc13588167f6"
+        		}], 
+        	"type": "image", 
+        	"id": "0d56500210a24c38a3702b6825e24164",
+        	"name": "glance"
+        	}, 
+        	{
+        	"endpoints": [
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "internal", 
+        		"id": "261aaf6239bb49a4a1cfa87c19859138"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "admin", 
+        		"id": "437d282e0bb94622aaacc4d194c069a9"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8776/v2/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "public", 
+        		"id": "5e78bf7bae7c4ff5b9720b2c2e4da743"
+        		}],
+        	"type": "volumev2", 
+        	"id": "2b92e79c45254516932c633229cd0e8b", 
+        	"name": "cinderv2"
+        	},
+        	{
+        	"endpoints": [
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8773/",
+        		"region": "RegionOne", 
+        		"interface": "admin", 
+        		"id": "1ce26a6fffd0424bac135b9c68055b6e"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8773/", 
+        		"region": "RegionOne", 
+        		"interface": "public", 
+        		"id": "98db699b9ffa4dffb027d78163aad8cc"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8773/", 
+        		"region": "RegionOne", 
+        		"interface": "internal", 
+        		"id": "ece52860cf1e4eb6a8fed05c47a30147"
+        		}],
+        	"type": "ec2", 
+        	"id": "3364a7b95c664bf89a7a8db081576364", 
+        	"name": "ec2"
+        	}, 
+        	{
+        	"endpoints": [
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "admin", 
+        		"id": "4442fbd064844a7bbe6a792507d4b8e3"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "internal", 
+        		"id": "4b4178fd2e3d4f329600cc4ceaaa7e3a"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8776/v1/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 	
+        		"interface": "public", 
+        		"id": "90977723dba04ea9a2a184c99565ccff"
+        		}],
+        	"type": "volume", 
+        	"id": "511b94ce0482484ea09028091dd5e9a5", 
+        	"name": "cinder"
+        	},
+        	{
+        	"endpoints": [
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "internal", 
+        		"id": "81c51855280345e9a6c322ca986d4e4b"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "admin", 
+        		"id": "a0310a37cf6144a6a967cbae9a7959ba"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8774/v2/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "public", 
+        		"id": "f6d38c03b9c04a9e924aaa288ce014b8"
+        		}],
+        	"type": "compute", 
+        	"id": "5b7028751ed045d79467c7845ecb8c58", 
+        	"name": "nova"
+        	},
+        	{
+        	"endpoints": [
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "internal", 
+        		"id": "2f17e155b0aa47838394e6c4f6fe30e0"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "public", 
+        		"id": "9d2555fd27dd44e5acfb5e56127d974b"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:8774/v2.1/123ac695d4db400a9001b91bb3b8aa46",
+        		"region": "RegionOne", 
+        		"interface": "admin", 
+        		"id": "e8bdd9403fbb4efa8d77bfd4f6a5e34a"
+        		}],
+        	"type": "computev21", 
+        	"id": "97e665cbada043718180c5a6316df76a", 
+        	"name": "novav21"
+        	},
+        	{
+        	"endpoints": [
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:35357/v3",
+        		"region": "RegionOne", 
+        		"interface": "admin", 
+        		"id": "185eda94de9340e58245062f75d7f80e"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:5000/v3", 
+        		"region": "RegionOne", 
+        		"interface": "internal", 
+        		"id": "9abd6797844d455f875af9537325cba4"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:5000/v3", 
+        		"region": "RegionOne", 
+        		"interface": "public", 
+        		"id": "d3b31f24e4ea40699f731e29e625c187"
+        		}],
+        	"type": "identity", 
+        	"id": "b577d8f7c7074d04a1165fcca638b600", 
+        	"name": "keystone_v3x"
+        	},
+        	{
+        	"endpoints": [
+        	{
+        		"region_id": "europe", 
+        		"url": "http://devstack.openstack.stack:35357/v3",
+        		"region": "europe", 
+        		"interface": "admin", 
+        		"id": "32bb2c6aea944ea6b4956eb24142d2e2"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:5000/v3", 
+        		"region": "RegionOne", 
+        		"interface": "public", 
+        		"id": "480ea71dc8cf4c959df1c6304be87056"
+        		},
+        	{
+        		"region_id": "europe", 
+        		"url": "http://devstack.openstack.stack:5000/v3", 
+        		"region": "europe", 
+        		"interface": "public", 
+        		"id": "600638643d22494fad4f30e3b22ae124"
+        		},
+        	{
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:5000/v3", 
+        		"region": "RegionOne", 
+        		"interface": "internal", 
+        		"id": "8a254651925e4a3e9505c863a00c017e"
+        		},
+        	{
+        		"region_id": "europe", 
+        		"url": "http://devstack.openstack.stack:5000/v3", 
+        		"region": "europe", 
+        		"interface": "internal", 
+        		"id": "b93da6aaba654d8cb451ff8378d7d2a5"
+        		},
+        	{	
+        		"region_id": "RegionOne", 
+        		"url": "http://devstack.openstack.stack:35357/v3", 
+        		"region": "RegionOne", 
+        		"interface": "admin", 
+        		"id": "d5f8e0da0f3345529a5fb324d735d4a3"
+        		}],
+        	"type": "identity_v3", 
+        	"id": "cd9002bbadfe495d81b5ee4c50768009", 
+        	"name": "keystone_v3"
+        }],
+		"extras": {},
+		"user": {
+			"domain": {
+				"id": "default",
+				"name": "Default"
+			},
+			"id": "aa9f25defa6d4cafb48466df83106065",
+			"name": "admin"
+		},
+		"audit_ids": ["jcxRTXu9T5e9giMO57cE3A","FJwqoPgBQf-W3e9jqC3dcA"],
+		"issued_at": "2015-08-26T13:14:09.542711Z"
+	}
+}

--- a/core-test/src/main/resources/identity.v3/authv3_unscoped.json
+++ b/core-test/src/main/resources/identity.v3/authv3_unscoped.json
@@ -1,0 +1,17 @@
+{
+    "token": {
+        "methods": ["password"],
+        "expires_at": "2015-08-26T14:14:10.395363Z",
+        "extras": {},
+        "user": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "aa9f25defa6d4cafb48466df83106065",
+            "name": "admin"
+        },
+        "audit_ids": ["jMpsNK77TA6hwF6bbBHQYA"],
+        "issued_at": "2015-08-26T13:14:10.395414Z"
+    }
+}

--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneGroup.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneGroup.java
@@ -7,14 +7,18 @@ import org.openstack4j.model.identity.builder.v3.GroupBuilder;
 import org.openstack4j.model.identity.v3.Group;
 import org.openstack4j.openstack.common.ListResult;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.Objects;
 
 /**
  * group model class for identity.v3
- * 
+ *
  * @see <a href="http://developer.openstack.org/api-ref-identity-v3.html#groups-v3">API reference</a>
  */
+@JsonRootName("group")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KeystoneGroup implements Group {
 
     private static final long serialVersionUID = 1L;
@@ -39,6 +43,7 @@ public class KeystoneGroup implements Group {
     /**
      * @return the id of the group
      */
+    @Override
     public String getId() {
         return id;
     }
@@ -46,6 +51,7 @@ public class KeystoneGroup implements Group {
     /**
      * @return the name of the group
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -53,6 +59,7 @@ public class KeystoneGroup implements Group {
     /**
      * @return the description of the group
      */
+    @Override
     public String getDescription() {
         return description;
     }
@@ -60,6 +67,7 @@ public class KeystoneGroup implements Group {
     /**
      * @return the domainId of the group
      */
+    @Override
     public String getDomainId() {
         return domainId;
     }
@@ -67,6 +75,7 @@ public class KeystoneGroup implements Group {
     /**
      * @return the links of the group
      */
+    @Override
     public Map<String, String> getLinks() {
         return links;
     }
@@ -74,6 +83,7 @@ public class KeystoneGroup implements Group {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String toString() {
         return Objects.toStringHelper(this).omitNullValues()
                 .add("id", id)
@@ -188,6 +198,7 @@ public class KeystoneGroup implements Group {
         @JsonProperty("groups")
         protected List<KeystoneGroup> list;
 
+        @Override
         public List<KeystoneGroup> value() {
             return list;
         }

--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneProject.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneProject.java
@@ -15,7 +15,7 @@ import com.google.common.base.Objects;
 
 /**
  * Project model class for identity.v3
- * 
+ *
  * @see <a href="http://developer.openstack.org/api-ref-identity-v3.html#projects-v3">API reference</a>
  */
 @JsonRootName("project")
@@ -29,6 +29,7 @@ public class KeystoneProject implements Project {
     private String name;
     @JsonProperty
     private KeystoneDomain domain;
+    @JsonProperty("domain_id")
     private String domainId;
     private String description;
     private Map<String, String> links;
@@ -52,6 +53,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the id of the project
      */
+    @Override
     public String getId() {
         return id;
     }
@@ -59,6 +61,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the domain the project belongs to
      */
+    @Override
     public Domain getDomain() {
         return domain;
     }
@@ -66,6 +69,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the domain id of the project
      */
+    @Override
     public String getDomainId() {
         if (domainId == null && domain != null && domain.getId() != null)
             domainId = domain.getId();
@@ -75,6 +79,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the description of the project
      */
+    @Override
     public String getDescription() {
         return description;
     }
@@ -82,6 +87,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the name of the project
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -97,6 +103,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the parentId of the project
      */
+    @Override
     public String getParentId() {
         return parentId;
     }
@@ -104,6 +111,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the subtree of the project
      */
+    @Override
     public String getSubtree() {
         return subtree;
     }
@@ -111,6 +119,7 @@ public class KeystoneProject implements Project {
     /**
      * @return the parents of the project
      */
+    @Override
     public String getParents() {
         return parents;
     }
@@ -125,7 +134,7 @@ public class KeystoneProject implements Project {
 
     /**
      * set project enabled
-     * 
+     *
      * @param enabled
      *            the new enabled status
      */
@@ -136,6 +145,7 @@ public class KeystoneProject implements Project {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String toString() {
         return Objects.toStringHelper(this).omitNullValues()
                 .add("id", id)
@@ -193,6 +203,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getId()
          */
+        @Override
         public ProjectBuilder id(String id) {
             model.id = id;
             return this;
@@ -201,6 +212,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getDomainId()
          */
+        @Override
         public ProjectBuilder domain(Domain domain) {
             if (domain != null && domain.getId() != null)
                 model.domainId = domain.getId();
@@ -210,6 +222,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getDescription()
          */
+        @Override
         public ProjectBuilder description(String description) {
             model.description = description;
             return this;
@@ -218,6 +231,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getName()
          */
+        @Override
         public ProjectBuilder name(String name) {
             model.name = name;
             return this;
@@ -226,6 +240,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getLinks()
          */
+        @Override
         public ProjectBuilder links(Map<String, String> links) {
             model.links = links;
             return this;
@@ -234,6 +249,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getParentId()
          */
+        @Override
         public ProjectBuilder parentId(String parentId) {
             model.parentId = parentId;
             return this;
@@ -242,6 +258,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getSubtree()
          */
+        @Override
         public ProjectBuilder subtree(String subtree) {
             model.subtree = subtree;
             return this;
@@ -250,6 +267,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#getParents()
          */
+        @Override
         public ProjectBuilder parents(String parents) {
             model.parents = parents;
             return this;
@@ -258,6 +276,7 @@ public class KeystoneProject implements Project {
         /**
          * @see KeystoneProject#isEnabled()
          */
+        @Override
         public ProjectBuilder enabled(boolean enabled) {
             model.enabled = enabled;
             return this;
@@ -295,6 +314,7 @@ public class KeystoneProject implements Project {
         @JsonProperty("projects")
         protected List<KeystoneProject> list;
 
+        @Override
         public List<KeystoneProject> value() {
             return list;
         }

--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneRole.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneRole.java
@@ -7,12 +7,16 @@ import org.openstack4j.model.identity.builder.v3.RoleBuilder;
 import org.openstack4j.model.identity.v3.Role;
 import org.openstack4j.openstack.common.ListResult;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.Objects;
 
 /**
  * v3 role implementation
  */
+@JsonRootName("role")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KeystoneRole implements Role {
 
     private static final long serialVersionUID = 1L;
@@ -34,6 +38,7 @@ public class KeystoneRole implements Role {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getId() {
         return id;
     }
@@ -41,6 +46,7 @@ public class KeystoneRole implements Role {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -48,6 +54,7 @@ public class KeystoneRole implements Role {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Map<String, String> getLinks() {
         return links;
     }
@@ -124,6 +131,7 @@ public class KeystoneRole implements Role {
         @JsonProperty("roles")
         protected List<KeystoneRole> list;
 
+        @Override
         public List<KeystoneRole> value() {
             return list;
         }

--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneService.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneService.java
@@ -10,12 +10,14 @@ import org.openstack4j.openstack.common.ListResult;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.google.common.base.Objects;
 
 /**
  * V3 OpenStack service
  *
  */
+@JsonRootName("service")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KeystoneService implements Service {
 
@@ -44,6 +46,7 @@ public class KeystoneService implements Service {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getId() {
         return id;
     }
@@ -51,6 +54,7 @@ public class KeystoneService implements Service {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getDescription() {
         return description;
     }
@@ -58,6 +62,7 @@ public class KeystoneService implements Service {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -65,6 +70,7 @@ public class KeystoneService implements Service {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getType() {
         return type;
     }
@@ -72,6 +78,7 @@ public class KeystoneService implements Service {
     /**
      * {@inheritDoc}
      */
+    @Override
     public List<? extends Endpoint> getEndpoints() {
         return endpoints;
     }
@@ -79,6 +86,7 @@ public class KeystoneService implements Service {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Map<String, String> getLinks() {
         return links;
     }

--- a/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneUser.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/domain/v3/KeystoneUser.java
@@ -15,10 +15,8 @@ import com.google.common.base.Objects;
 
 /**
  * User model class for identity.v3
- * 
- * @see <a href=
- *      "http://developer.openstack.org/api-ref-identity-v3.html#users-v3">API
- *      reference</a>
+ *
+ * @see <a href= "http://developer.openstack.org/api-ref-identity-v3.html#users-v3">API reference</a>
  */
 @JsonRootName("user")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -31,10 +29,12 @@ public class KeystoneUser implements User {
     private String name;
     @JsonProperty
     private KeystoneDomain domain;
+    @JsonProperty("domain_id")
     private String domainId;
     private String email;
     private String password;
     private String description;
+    @JsonProperty("default_project_id")
     private String defaultProjectId;
     private Map<String, String> links;
     private Boolean enabled = true;
@@ -54,6 +54,7 @@ public class KeystoneUser implements User {
     /**
      * @return the id of the user
      */
+    @Override
     public String getId() {
         return id;
     }
@@ -61,6 +62,7 @@ public class KeystoneUser implements User {
     /**
      * @return the of the user
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -68,6 +70,7 @@ public class KeystoneUser implements User {
     /**
      * @return the email of the user
      */
+    @Override
     public String getEmail() {
         return email;
     }
@@ -75,6 +78,7 @@ public class KeystoneUser implements User {
     /**
      * @return the password of the user
      */
+    @Override
     public String getPassword() {
         return password;
     }
@@ -82,6 +86,7 @@ public class KeystoneUser implements User {
     /**
      * @return the description of the user
      */
+    @Override
     public String getDescription() {
         return description;
     }
@@ -89,6 +94,7 @@ public class KeystoneUser implements User {
     /**
      * @return the domainId of the user
      */
+    @Override
     public String getDomainId() {
         return domainId;
     }
@@ -96,6 +102,7 @@ public class KeystoneUser implements User {
     /**
      * @return the domain of the user
      */
+    @Override
     public Domain getDomain() {
         return domain;
     }
@@ -103,6 +110,7 @@ public class KeystoneUser implements User {
     /**
      * @return the defaultProjectId of the user
      */
+    @Override
     public String getDefaultProjectId() {
         return defaultProjectId;
     }
@@ -110,6 +118,7 @@ public class KeystoneUser implements User {
     /**
      * @return the links of the user
      */
+    @Override
     public Map<String, String> getLinks() {
         return links;
     }
@@ -117,13 +126,14 @@ public class KeystoneUser implements User {
     /**
      * @return the enabled of the user
      */
+    @Override
     public boolean isEnabled() {
         return enabled != null && enabled;
     }
 
     /**
      * set user enabled
-     * 
+     *
      * @param enabled
      *            the new enabled status
      */
@@ -131,6 +141,7 @@ public class KeystoneUser implements User {
         this.enabled = enabled;
     }
 
+    @Override
     public String toString() {
         return Objects.toStringHelper(this).omitNullValues()
                 .add("name", name)
@@ -151,6 +162,7 @@ public class KeystoneUser implements User {
         @JsonProperty("users")
         private List<KeystoneUser> list;
 
+        @Override
         public List<KeystoneUser> value() {
             return list;
         }
@@ -171,6 +183,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getId()
          */
+        @Override
         public UserBuilder id(String id) {
             model.id = id;
             return this;
@@ -179,6 +192,7 @@ public class KeystoneUser implements User {
         /**
          * @return the KeystoneUser model
          */
+        @Override
         public User build() {
             return model;
         }
@@ -196,6 +210,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getName()
          */
+        @Override
         public UserBuilder name(String name) {
             model.name = name;
             return this;
@@ -204,6 +219,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getDefaultProjectId()
          */
+        @Override
         public UserBuilder defaultProjectId(String defaultProjectId) {
             model.defaultProjectId = defaultProjectId;
             return this;
@@ -212,6 +228,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getDomainId()
          */
+        @Override
         public UserBuilder domainId(String domainId) {
             model.domainId = domainId;
             return this;
@@ -220,6 +237,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getDomain()
          */
+        @Override
         public UserBuilder domain(Domain domain) {
             // model.domain = domain;
             if (domain != null && domain.getId() != null)
@@ -230,6 +248,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getEmail()
          */
+        @Override
         public UserBuilder email(String email) {
             model.email = email;
             return this;
@@ -238,6 +257,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getPassword()
          */
+        @Override
         public UserBuilder password(String password) {
             model.password = password;
             return this;
@@ -246,6 +266,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getLinks()
          */
+        @Override
         public UserBuilder links(Map<String, String> links) {
             model.links = links;
             return this;
@@ -254,6 +275,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#isEnabled()
          */
+        @Override
         public UserBuilder enabled(boolean enabled) {
             model.enabled = enabled;
             return this;
@@ -262,6 +284,7 @@ public class KeystoneUser implements User {
         /**
          * @see KeystoneUser#getDescription()
          */
+        @Override
         public UserBuilder description(String description) {
             model.description = description;
             return this;


### PR DESCRIPTION
This PR related to issue Domain scoped authentication #497 and enables OpenStack4j to authenticate with a domain scope in the identity v3 case.
This is the last commit for this kind of issues which is compatible to the v2 implementation.