### PR TITLE
moved grant/revoke/check-role from user- to role-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ OSClient os = OSFactory.builder()
 ```
 (2) authenticate with domain-scope
 ```java
-// Identity V2 Authentication Example
 OSClient os = OSFactory.builder()
                 .endpoint("http://<fqdn>:5000/v3")
                 .credentials("admin", "secret", Identifier.byId("user domain id"))
@@ -184,15 +183,15 @@ User user = os.identity().users().create(Builders.user()
 User user = os.identity().users().create("domain id", "foobar", "secret", "foobar@example.org", true);
 
 // Get detailed info on a user by id
-os.identity().users.get("user id");
+User user = os.identity().users.get("user id");
 //or by name and domain identifier
-os.identity().users.getByName("username", "domain id");
+User user = os.identity().users.getByName("username", "domain id");
 
 // Add a project based role to the user
-os.identity().users().grantProjectUserRole("project id","user id", "role id");
+os.identity().roles().grantProjectUserRole("project id","user id", "role id");
 
 // Add a domain based role to the user
-os.identity().users().grantDomainUserRole("domain id","user id", "role id");
+os.identity().roles().grantDomainUserRole("domain id","user id", "role id");
 
 // Add a user to a group
 os.identity().users().addUserToGroup("user id", "group id");

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneAuthenticationTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneAuthenticationTests.java
@@ -285,7 +285,9 @@ public class KeystoneAuthenticationTests extends AbstractTest {
      */
     @Test(priority=-1)
     public void authenticate_userId_password_domain_region_Test() throws Exception {
+
         try {
+
             os().useRegion(REGION_EUROPE);
 
             respondWith(JSON_USERS);

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneProjectServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneProjectServiceTests.java
@@ -7,6 +7,10 @@ import org.openstack4j.api.Builders;
 import org.openstack4j.model.identity.Project;
 import org.testng.annotations.Test;
 
+/**
+ * Tests the Identity/Keystone API version 3 ProjectService
+ */
+@Test(groups = "idV3", suiteName = "Identity/V3/Keystone")
 public class KeystoneProjectServiceTests extends AbstractTest {
 
     private static final String JSON_PROJECTS_CREATE = "/identity/projects_create_response.json";

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneRoleServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneRoleServiceTests.java
@@ -17,6 +17,10 @@ public class KeystoneRoleServiceTests extends AbstractTest {
     private static final String JSON_ROLES_MULTIPLE_ENTRIES = "/identity/roles_multiple_entries.json";
     private static final String JSON_ROLES_LIST = "/identity/roles_list.json";
     private static final String ROLE_NAME = "admin";
+    private static final String USER_ID = "aa9f25defa6d4cafb48466df83106065";
+    private static final String PROJECT_ID = "123ac695d4db400a9001b91bb3b8aa46";
+    private static final String ROLE_ID = "aae88952465d4c32b0a1140a76601b68";
+    private static final String USER_DOMAIN_ID = "default";
 
     @Override
     protected Service service() {
@@ -50,17 +54,17 @@ public class KeystoneRoleServiceTests extends AbstractTest {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void addRoletoUserInProject_projectIdMustBeNonNull() throws Exception {
-        os().identity().roles().addRoleToUserInProject(null, "fake", "fake");
+        os().identity().roles().grantProjectUserRole(null, "fake", "fake");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void addRoletoUserInProject_userIdMustBeNonNull() throws Exception {
-        os().identity().roles().addRoleToUserInProject("fake", null, "fake");
+        os().identity().roles().grantProjectUserRole("fake", null, "fake");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void addRoletoUserInProject_roleIdMustBeNonNull() throws Exception {
-        os().identity().roles().addRoleToUserInProject("fake", "fake", null);
+        os().identity().roles().grantProjectUserRole("fake", "fake", null);
     }
 
     public void addRoleToUserInProject_check_correct_response() throws Exception {
@@ -68,7 +72,7 @@ public class KeystoneRoleServiceTests extends AbstractTest {
         ActionResponse actionResponse = os().
                 identity().
                 roles().
-                addRoleToUserInProject("fake", "fake", "fake");
+                grantProjectUserRole("fake", "fake", "fake");
         assertTrue(actionResponse.isSuccess());
     }
 
@@ -77,4 +81,70 @@ public class KeystoneRoleServiceTests extends AbstractTest {
         List<? extends Role> list = os().identity().roles().list();
         assertEquals(list.size(), 6);
     }
+
+    /**
+     * checks if a user has a role in project context
+     *
+     * @throws Exception
+     */
+    public void checkProjectUserRole_success_Test() throws Exception {
+
+        respondWith(204);
+
+        ActionResponse response_success = os().identity().roles().checkProjectUserRole(PROJECT_ID, USER_ID, ROLE_ID);
+        assertTrue(response_success.isSuccess());
+    }
+
+    /**
+     * grants and revokes a role to/from a user in project context
+     *
+     * @throws Exception
+     */
+    public void grantRevokeProjectUserRole_Test() throws Exception {
+
+        respondWith(204);
+
+        ActionResponse result_grant = os().identity().roles().grantProjectUserRole(PROJECT_ID, USER_ID, ROLE_ID);
+        assertTrue(result_grant.isSuccess());
+
+        respondWith(204);
+
+        ActionResponse result_revoke = os().identity().roles().revokeProjectUserRole(PROJECT_ID, USER_ID, ROLE_ID);
+        assertTrue(result_revoke.isSuccess());
+
+    }
+
+    /**
+     * checks if a user has a role in domain context
+     *
+     * @throws Exception
+     */
+    public void checkDomainUserRole_success_Test() throws Exception {
+
+        respondWith(204);
+
+        ActionResponse response_success = os().identity().roles().checkDomainUserRole(USER_DOMAIN_ID, USER_ID, ROLE_ID);
+        assertTrue(response_success.isSuccess());
+    }
+
+    /**
+     * grants and revokes a role to/from a user in domain context
+     *
+     * @throws Exception
+     */
+    public void grantRevokeDomainUserRole_Test() throws Exception {
+
+        respondWith(204);
+
+        ActionResponse result_grant = os().identity().roles().grantDomainUserRole(USER_DOMAIN_ID, USER_ID, ROLE_ID);
+        assertTrue(result_grant.isSuccess());
+
+        respondWith(204);
+
+        ActionResponse result_revoke = os().identity().roles().revokeDomainUserRole(USER_DOMAIN_ID, USER_ID, ROLE_ID);
+        assertTrue(result_revoke.isSuccess());
+
+    }
+
+
 }

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneRoleServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneRoleServiceTests.java
@@ -1,6 +1,7 @@
 package org.openstack4j.api.identity;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
@@ -10,12 +11,18 @@ import org.openstack4j.model.compute.ActionResponse;
 import org.openstack4j.model.identity.Role;
 import org.testng.annotations.Test;
 
+/**
+ * Tests the Identity/Keystone API version 3 RoleService
+ */
+@Test(groups = "idV3", suiteName = "Identity/V3/Keystone")
 public class KeystoneRoleServiceTests extends AbstractTest {
 
     private static final String JSON_ROLES_EMPTY = "/identity/roles_empty.json";
     private static final String JSON_ROLES_ONE_ENTRY = "/identity/roles_one_entry.json";
     private static final String JSON_ROLES_MULTIPLE_ENTRIES = "/identity/roles_multiple_entries.json";
     private static final String JSON_ROLES_LIST = "/identity/roles_list.json";
+    private static final String JSON_ROLES_REVOKEROLE_ERROR = "/identity/roles_revokeRole_error.json";
+    private static final String JSON_ROLES_GRANTROLE_ERROR = "/identity/roles_grantRole_error.json";
     private static final String ROLE_NAME = "admin";
     private static final String USER_ID = "aa9f25defa6d4cafb48466df83106065";
     private static final String PROJECT_ID = "123ac695d4db400a9001b91bb3b8aa46";
@@ -95,6 +102,22 @@ public class KeystoneRoleServiceTests extends AbstractTest {
         assertTrue(response_success.isSuccess());
     }
 
+    //TODO: this test is disabled due to a malformed response returned by OpenStack as described in issue #530
+    /**
+     * checks if a user has a role in domain context
+     *
+     * @throws Exception
+     */
+    @Test(enabled=false)
+    public void checkProjectUserRole_fail_Test() throws Exception {
+
+        respondWith(404);
+
+        ActionResponse response_success = os().identity().roles().checkProjectUserRole(PROJECT_ID, USER_ID, "existingUnassignedRoleId");
+        assertFalse(response_success.isSuccess());
+
+    }
+
     /**
      * grants and revokes a role to/from a user in project context
      *
@@ -115,6 +138,33 @@ public class KeystoneRoleServiceTests extends AbstractTest {
     }
 
     /**
+     * try to grant a project role to a user using role that doesn't exist results in failing ActionResponse
+     *
+     * @throws Exception
+     */
+    public void grantProjectUserRole_fail_Test() throws Exception {
+
+        respondWithCodeAndResource(404, JSON_ROLES_GRANTROLE_ERROR);
+
+        ActionResponse response_fail = os().identity().roles().grantProjectUserRole(PROJECT_ID, USER_ID, "nonExistingRoleId");
+        assertFalse(response_fail.isSuccess());
+
+    }
+
+    /**
+     * try to revoke a project role from a user that isn't assigned to him results in failing ActionResponse
+     *
+     * @throws Exception
+     */
+    public void revokeProjectUserRole_fail_Test() throws Exception {
+
+        respondWithCodeAndResource(404, JSON_ROLES_REVOKEROLE_ERROR);
+
+        ActionResponse response_fail = os().identity().roles().revokeProjectUserRole(PROJECT_ID, USER_ID, "existingUnassignedRoleId");
+        assertFalse(response_fail.isSuccess());
+    }
+
+    /**
      * checks if a user has a role in domain context
      *
      * @throws Exception
@@ -125,6 +175,22 @@ public class KeystoneRoleServiceTests extends AbstractTest {
 
         ActionResponse response_success = os().identity().roles().checkDomainUserRole(USER_DOMAIN_ID, USER_ID, ROLE_ID);
         assertTrue(response_success.isSuccess());
+    }
+
+    //TODO: this test is disabled due to a malformed response returned by OpenStack as described in issue #530
+    /**
+     * checks if a user has a role in domain context
+     *
+     * @throws Exception
+     */
+    @Test(enabled=false)
+    public void checkDomainUserRole_fail_Test() throws Exception {
+
+        respondWith(404);
+
+        ActionResponse response_success = os().identity().roles().checkDomainUserRole(USER_DOMAIN_ID, USER_ID, "existingUnassignedRoleId");
+        assertFalse(response_success.isSuccess());
+
     }
 
     /**
@@ -146,5 +212,32 @@ public class KeystoneRoleServiceTests extends AbstractTest {
 
     }
 
+    /**
+     * try to grant a domain role to a user using a role that doesn't exist results in failing ActionResponse
+     *
+     * @throws Exception
+     */
+    public void grantDomainUserRole_fail_Test() throws Exception {
+
+        respondWithCodeAndResource(404, JSON_ROLES_GRANTROLE_ERROR);
+
+        ActionResponse response_fail = os().identity().roles().grantDomainUserRole(USER_DOMAIN_ID, USER_ID, "nonExistingRoleId");
+        assertFalse(response_fail.isSuccess());
+
+    }
+
+    /**
+     * try to revoke a domain role from a user that isn't assigned to him results in failing ActionResponse
+     *
+     * @throws Exception
+     */
+    public void revokeDomainUserRole_fail_Test() throws Exception {
+
+        respondWithCodeAndResource(404, JSON_ROLES_REVOKEROLE_ERROR);
+
+        ActionResponse response_fail = os().identity().roles().revokeDomainUserRole(USER_DOMAIN_ID, USER_ID, "existingUnassignedRoleId");
+        assertFalse(response_fail.isSuccess());
+
+    }
 
 }

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneUserServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneUserServiceTests.java
@@ -41,7 +41,6 @@ public class KeystoneUserServiceTests extends AbstractTest {
     private static final String USER_ID = "aa9f25defa6d4cafb48466df83106065";
     private static final String USER_DOMAIN_ID = "default";
     private static final String PROJECT_ID = "123ac695d4db400a9001b91bb3b8aa46";
-    private static final String ROLE_ID = "aae88952465d4c32b0a1140a76601b68";
     private static final String ANOTHER_GROUP_ID = "ea167b";
 
     /**
@@ -185,32 +184,6 @@ public class KeystoneUserServiceTests extends AbstractTest {
     }
 
     /**
-     * checks if a user has a role in domain context
-     *
-     * @throws Exception
-     */
-    public void checkDomainUserRole_success_Test() throws Exception {
-
-        respondWith(204);
-
-        ActionResponse response_success = os().identity().users().checkDomainUserRole(USER_DOMAIN_ID, USER_ID, ROLE_ID);
-        assertTrue(response_success.isSuccess());
-    }
-
-    /**
-     * checks if a user has a role in project context
-     *
-     * @throws Exception
-     */
-    public void checkProjectUserRole_success_Test() throws Exception {
-
-        respondWith(204);
-
-        ActionResponse response_success = os().identity().users().checkProjectUserRole(PROJECT_ID, USER_ID, ROLE_ID);
-        assertTrue(response_success.isSuccess());
-    }
-
-    /**
      * list roles for a user in domain context
      *
      * @throws Exception
@@ -293,43 +266,4 @@ public class KeystoneUserServiceTests extends AbstractTest {
         assertFalse(result_add_fail.isSuccess());
 
     }
-
-    /**
-     * grants and revokes a role to/from a user in domain context
-     *
-     * @throws Exception
-     */
-    public void grantRevokeDomainUserRole_Test() throws Exception {
-
-        respondWith(204);
-
-        ActionResponse result_grant = os().identity().users().grantDomainUserRole(USER_DOMAIN_ID, USER_ID, ROLE_ID);
-        assertTrue(result_grant.isSuccess());
-
-        respondWith(204);
-
-        ActionResponse result_revoke = os().identity().users().revokeDomainUserRole(USER_DOMAIN_ID, USER_ID, ROLE_ID);
-        assertTrue(result_revoke.isSuccess());
-
-    }
-
-    /**
-     * grants and revokes a role to/from a user in project context
-     *
-     * @throws Exception
-     */
-    public void grantRevokeProjectUserRole_Test() throws Exception {
-
-        respondWith(204);
-
-        ActionResponse result_grant = os().identity().users().grantProjectUserRole(PROJECT_ID, USER_ID, ROLE_ID);
-        assertTrue(result_grant.isSuccess());
-
-        respondWith(204);
-
-        ActionResponse result_revoke = os().identity().users().revokeProjectUserRole(PROJECT_ID, USER_ID, ROLE_ID);
-        assertTrue(result_revoke.isSuccess());
-
-    }
-
 }

--- a/core-test/src/main/resources/identity/roles_grantRole_error.json
+++ b/core-test/src/main/resources/identity/roles_grantRole_error.json
@@ -1,0 +1,7 @@
+{
+    "error": {
+        "message": "Could not find role: nonExistingRoleId",
+        "code": 404,
+        "title": "Not Found"
+    }
+}

--- a/core-test/src/main/resources/identity/roles_revokeRole_error.json
+++ b/core-test/src/main/resources/identity/roles_revokeRole_error.json
@@ -1,0 +1,7 @@
+{
+    "error": {
+        "message": "Could not find role assignment with role: anotherExistingUnassignedRoleId, user or group: aa9f25defa6d4cafb48466df83106065, project or domain: 123ac695d4db400a9001b91bb3b8aa46",
+        "code": 404,
+        "title": "Not Found"
+    }
+}

--- a/core/src/main/java/org/openstack4j/api/identity/RoleService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/RoleService.java
@@ -12,15 +12,65 @@ import org.openstack4j.model.identity.Role;
  */
 public interface RoleService extends RestService {
 
-	/**
-	 * Adds a project based role to a user
-	 *
-	 * @param projectId the project id
-	 * @param userId the user id
-	 * @param roleId the role id
-	 * @return the action response
-	 */
-	ActionResponse addRoleToUserInProject(String projectId, String userId, String roleId);
+    /**
+     * grants a role to a specified user in project context
+     *
+     * @param projectId the project id
+     * @param userId the user id
+     * @param roleId the role id
+     * @return the action response
+     */
+    ActionResponse grantProjectUserRole(String projectId, String userId, String roleId);
+
+    /**
+     * revokes a role to a specified user in project context
+     *
+     * @param projectId the project id
+     * @param userId the user id
+     * @param roleId the role id
+     * @return the action response
+     */
+    ActionResponse revokeProjectUserRole(String projectId, String userId, String roleId);
+
+    /**
+     * checks if a user has a specific role in a given project-context
+     *
+     * @param projectId the project id
+     * @param userId the user id
+     * @param roleId the role id
+     * @return the ActionResponse
+     */
+    ActionResponse checkProjectUserRole(String projectId, String userId, String roleId);
+
+    /**
+     * grants a role to a specified user in domain context
+     *
+     * @param domainId the domain id
+     * @param userId the user id
+     * @param roleId the role id
+     * @return the action response
+     */
+    ActionResponse grantDomainUserRole(String domainId, String userId, String roleId);
+
+    /**
+     * revokes a role to a specified user in domain context
+     *
+     * @param domainId the domain id
+     * @param userId the user id
+     * @param roleId the role id
+     * @return the action response
+     */
+    ActionResponse revokeDomainUserRole(String domainId, String userId, String roleId);
+
+    /**
+     * checks if a user has a specific role in a given domain-context
+     *
+     * @param domainId the domain id
+     * @param userId the user id
+     * @param roleId the role id
+     * @return the ActionResponse
+     */
+    ActionResponse checkDomainUserRole(String domainId, String userId, String roleId);
 
 	/**
 	 * Lists the global roles

--- a/core/src/main/java/org/openstack4j/api/identity/UserService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/UserService.java
@@ -117,66 +117,6 @@ public interface UserService extends RestService {
 	 */
 	List<? extends Role> listDomainUserRoles(String userId, String domainId);
 
-	/**
-	 * grants a role to a specified user in domain context
-	 *
-	 * @param domainId the domain id
-	 * @param userId the user id
-	 * @param roleId the role id
-	 * @return the action response
-	 */
-	ActionResponse grantDomainUserRole(String domainId, String userId, String roleId);
-
-	/**
-	 * revokes a role to a specified user in domain context
-	 *
-	 * @param domainId the domain id
-	 * @param userId the user id
-	 * @param roleId the role id
-	 * @return the action response
-	 */
-	ActionResponse revokeDomainUserRole(String domainId, String userId, String roleId);
-
-	/**
-     * grants a role to a specified user in project context
-     *
-     * @param projectId the project id
-     * @param userId the user id
-     * @param roleId the role id
-     * @return the action response
-     */
-	ActionResponse grantProjectUserRole(String projectId, String userId, String roleId);
-
-	/**
-     * revokes a role to a specified user in project context
-     *
-     * @param projectId the project id
-     * @param userId the user id
-     * @param roleId the role id
-     * @return the action response
-     */
-	ActionResponse revokeProjectUserRole(String projectId, String userId, String roleId);
-
-	/**
-     * checks if a user has a specific role in a given domain-context
-     *
-     * @param domainId the domain id
-     * @param userId the user id
-     * @param roleId the role id
-     * @return the ActionResponse
-     */
-    ActionResponse checkDomainUserRole(String domainId, String userId, String roleId);
-
-    /**
-     * checks if a user has a specific role in a given project-context
-     *
-     * @param projectId the project id
-     * @param userId the user id
-     * @param roleId the role id
-     * @return the ActionResponse
-     */
-    ActionResponse checkProjectUserRole(String projectId, String userId, String roleId);
-
     /**
      * adds an existing user to an existing group
      *

--- a/core/src/main/java/org/openstack4j/core/transport/functions/ResponseToActionResponse.java
+++ b/core/src/main/java/org/openstack4j/core/transport/functions/ResponseToActionResponse.java
@@ -10,23 +10,23 @@ import com.google.common.base.Function;
 
 /**
  * Takes an HttpResponse as input and returns an ActionResponse as an output
- * 
+ *
  * @author Jeremy Unruh
  */
 public class ResponseToActionResponse implements Function<HttpResponse, ActionResponse> {
 
     public static final ResponseToActionResponse INSTANCE = new ResponseToActionResponse();
-    
+
     @Override
     public ActionResponse apply(HttpResponse response) {
-       return apply(response, false);  
+       return apply(response, false);
     }
 
     public ActionResponse apply(HttpResponse response, boolean returnNullIfNotMapped) {
         if (Parser.isContentTypeText(response.getContentType())) {
             return ActionResponse.actionFailed(response.getStatusMessage(), response.getStatus());
         }
-        
+
         @SuppressWarnings("unchecked")
         Map<String, Object> map = response.readEntity(Map.class);
         ActionResponse ar = new ParseActionResponseFromJsonMap(response).apply(map);
@@ -35,7 +35,7 @@ public class ResponseToActionResponse implements Function<HttpResponse, ActionRe
 
         if (ar == null && returnNullIfNotMapped)
             return null;
-        
-        return ActionResponse.actionFailed(String.format("Status: %d, Reason: %s", response.getStatus(), response.getStatusMessage()), response.getStatus()); 
+
+        return ActionResponse.actionFailed(String.format("Status: %d, Reason: %s", response.getStatus(), response.getStatusMessage()), response.getStatus());
     }
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/ProjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/ProjectServiceImpl.java
@@ -8,12 +8,15 @@ import org.openstack4j.model.identity.Project;
 import org.openstack4j.openstack.identity.domain.KeystoneProject;
 import org.openstack4j.openstack.internal.BaseOpenStackService;
 
-public class ProjectServiceImpl extends BaseOpenStackService implements ProjectService  {
+public class ProjectServiceImpl extends BaseOpenStackService implements ProjectService {
 
-	@Override
-	public Project create(Project project) {
-		checkNotNull(project);
-		return post(KeystoneProject.class, PATH_PROJECTS).entity(project).execute();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Project create(Project project) {
+        checkNotNull(project);
+        return post(KeystoneProject.class, PATH_PROJECTS).entity(project).execute();
+    }
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/RoleServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/RoleServiceImpl.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.identity.RoleService;
-import org.openstack4j.core.transport.HttpMethod;
 import org.openstack4j.model.compute.ActionResponse;
 import org.openstack4j.model.identity.Role;
 import org.openstack4j.openstack.identity.domain.KeystoneRole.Roles;
@@ -17,34 +16,88 @@ import org.openstack4j.openstack.internal.BaseOpenStackService;
  */
 public class RoleServiceImpl extends BaseOpenStackService implements RoleService {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public ActionResponse addRoleToUserInProject(String projectId, String userId, String roleId) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse grantProjectUserRole(String projectId, String userId, String roleId) {
+        checkNotNull(userId);
+        checkNotNull(projectId);
+        checkNotNull(roleId);
+        return put(ActionResponse.class, uri("projects/%s/users/%s/roles/%s", projectId, userId, roleId)).execute();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse revokeProjectUserRole(String projectId, String userId, String roleId) {
+        checkNotNull(userId);
+        checkNotNull(projectId);
+        checkNotNull(roleId);
+        return deleteWithResponse(uri("projects/%s/users/%s/roles/%s", projectId, userId, roleId)).execute();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse checkProjectUserRole(String projectId, String userId, String roleId) {
         checkNotNull(projectId);
         checkNotNull(userId);
         checkNotNull(roleId);
-        String uri = uri("/projects/%s/users/%s/roles/%s", projectId, userId, roleId);
-        return request(HttpMethod.PUT, ActionResponse.class, uri).execute();
-	}
+        return head(ActionResponse.class, uri("/projects/%s/users/%s/roles/%s", projectId, userId, roleId)).execute();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public List<? extends Role> list() {
-		return get(Roles.class, uri("/roles")).execute().getList();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse grantDomainUserRole(String domainId, String userId, String roleId) {
+        checkNotNull(userId);
+        checkNotNull(domainId);
+        checkNotNull(roleId);
+        return put(ActionResponse.class, uri("domains/%s/users/%s/roles/%s", domainId, userId, roleId)).execute();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public List<? extends Role> getByName(String name) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse revokeDomainUserRole(String domainId, String userId, String roleId) {
+        checkNotNull(userId);
+        checkNotNull(domainId);
+        checkNotNull(roleId);
+        return deleteWithResponse(uri("domains/%s/users/%s/roles/%s", domainId, userId, roleId)).execute();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse checkDomainUserRole(String domainId, String userId, String roleId) {
+        checkNotNull(domainId);
+        checkNotNull(userId);
+        checkNotNull(roleId);
+        return head(ActionResponse.class, uri("/domains/%s/users/%s/roles/%s", domainId, userId, roleId)).execute();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends Role> list() {
+        return get(Roles.class, uri("/roles")).execute().getList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends Role> getByName(String name) {
         checkNotNull(name);
         return get(Roles.class, "/roles").param("name", name).execute().getList();
 
-	}
+    }
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/UserServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/UserServiceImpl.java
@@ -14,10 +14,10 @@ import org.openstack4j.model.identity.Project;
 import org.openstack4j.model.identity.Role;
 import org.openstack4j.model.identity.User;
 import org.openstack4j.openstack.identity.domain.KeystoneDomain;
-import org.openstack4j.openstack.identity.domain.KeystoneUser;
 import org.openstack4j.openstack.identity.domain.KeystoneGroup.Groups;
 import org.openstack4j.openstack.identity.domain.KeystoneProject.Projects;
 import org.openstack4j.openstack.identity.domain.KeystoneRole.Roles;
+import org.openstack4j.openstack.identity.domain.KeystoneUser;
 import org.openstack4j.openstack.identity.domain.KeystoneUser.Users;
 import org.openstack4j.openstack.internal.BaseOpenStackService;
 
@@ -27,82 +27,121 @@ import org.openstack4j.openstack.internal.BaseOpenStackService;
  */
 public class UserServiceImpl extends BaseOpenStackService implements UserService {
 
-	@Override
-	public User get(String userId) {
-		checkNotNull(userId);
-		return get(KeystoneUser.class, PATH_USERS, "/", userId).execute();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public User get(String userId) {
+        checkNotNull(userId);
+        return get(KeystoneUser.class, PATH_USERS, "/", userId).execute();
+    }
 
-	@Override
-	public List<? extends User> getByName(String userName) {
-		checkNotNull(userName);
-		return get(Users.class, uri(PATH_USERS)).param("name", userName).execute().getList();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends User> getByName(String userName) {
+        checkNotNull(userName);
+        return get(Users.class, uri(PATH_USERS)).param("name", userName).execute().getList();
+    }
 
-	@Override
-	public User getByName(String userName, String domainId) {
-	    checkNotNull(userName);
-	    checkNotNull(domainId);
-	    return get(Users.class, uri(PATH_USERS)).param("name", userName).param("domain_id", domainId).execute().getList().get(0);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public User getByName(String userName, String domainId) {
+        checkNotNull(userName);
+        checkNotNull(domainId);
+        return get(Users.class, uri(PATH_USERS)).param("name", userName).param("domain_id", domainId).execute().getList().get(0);
+    }
 
-	@Override
-	public Domain getUserDomain(String userId) {
-	    return get(KeystoneDomain.class, PATH_DOMAINS, "/", get(userId).getDomainId()).execute();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Domain getUserDomain(String userId) {
+        return get(KeystoneDomain.class, PATH_DOMAINS, "/", get(userId).getDomainId()).execute();
+    }
 
-	@Override
-	public ActionResponse delete(String userId) {
-		checkNotNull(userId);
-		return deleteWithResponse(PATH_USERS, "/", userId).execute();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ActionResponse delete(String userId) {
+        checkNotNull(userId);
+        return deleteWithResponse(PATH_USERS, "/", userId).execute();
+    }
 
-	@Override
-	public User update(User user) {
-	    checkNotNull(user);
-		return patch(KeystoneUser.class, PATH_USERS, "/", user.getId()).entity(user).execute();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public User update(User user) {
+        checkNotNull(user);
+        return patch(KeystoneUser.class, PATH_USERS, "/", user.getId()).entity(user).execute();
+    }
 
-	@Override
-	public User create(User user) {
-		checkNotNull(user);
-		return post(KeystoneUser.class, uri(PATH_USERS)).entity(user).execute();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public User create(User user) {
+        checkNotNull(user);
+        return post(KeystoneUser.class, uri(PATH_USERS)).entity(user).execute();
+    }
 
-	@Override
-	public User create(String domainId, String name, String password, String email, boolean enabled) {
-	    checkNotNull(domainId);
-	    checkNotNull(name);
-	    checkNotNull(password);
-	    checkNotNull(email);
-	    checkNotNull(enabled);
-	    return create(KeystoneUser.builder().domainId(domainId).name(name).password(password).email(email).enabled(enabled).build());
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public User create(String domainId, String name, String password, String email, boolean enabled) {
+        checkNotNull(domainId);
+        checkNotNull(name);
+        checkNotNull(password);
+        checkNotNull(email);
+        checkNotNull(enabled);
+        return create(KeystoneUser.builder().domainId(domainId).name(name).password(password).email(email).enabled(enabled).build());
+    }
 
-	@Override
-	public List<? extends Group> listUserGroups(String userId) {
-		checkNotNull(userId);
-		return get(Groups.class, uri("/users/%s/groups", userId)).execute().getList();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends Group> listUserGroups(String userId) {
+        checkNotNull(userId);
+        return get(Groups.class, uri("/users/%s/groups", userId)).execute().getList();
+    }
 
-	@Override
-	public List<? extends Project> listUserProjects(String userId) {
-		checkNotNull(userId);
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends Project> listUserProjects(String userId) {
+        checkNotNull(userId);
         return get(Projects.class, uri("/users/%s/projects", userId)).execute().getList();
-	}
+    }
 
-	@Override
-	public List<? extends User> list() {
-		return get(Users.class, uri(PATH_USERS)).execute().getList();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends User> list() {
+        return get(Users.class, uri(PATH_USERS)).execute().getList();
+    }
 
-	@Override
-	public List<? extends Role> listProjectUserRoles(String userId, String projectId) {
-		checkNotNull(userId);
-		checkNotNull(projectId);
-		return get(Roles.class, uri("projects/%s/users/%s/roles", projectId, userId)).execute().getList();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends Role> listProjectUserRoles(String userId, String projectId) {
+        checkNotNull(userId);
+        checkNotNull(projectId);
+        return get(Roles.class, uri("projects/%s/users/%s/roles", projectId, userId)).execute().getList();
+    }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<? extends Role> listDomainUserRoles(String userId, String domainId) {
         checkNotNull(userId);
@@ -110,54 +149,9 @@ public class UserServiceImpl extends BaseOpenStackService implements UserService
         return get(Roles.class, uri("domains/%s/users/%s/roles", domainId, userId)).execute().getList();
     }
 
-    @Override
-    public ActionResponse grantDomainUserRole(String domainId, String userId, String roleId) {
-        checkNotNull(userId);
-        checkNotNull(domainId);
-        checkNotNull(roleId);
-        return put(ActionResponse.class, uri("domains/%s/users/%s/roles/%s", domainId, userId, roleId)).execute();
-    }
-
-    @Override
-    public ActionResponse revokeDomainUserRole(String domainId, String userId, String roleId) {
-        checkNotNull(userId);
-        checkNotNull(domainId);
-        checkNotNull(roleId);
-        return deleteWithResponse(uri("domains/%s/users/%s/roles/%s", domainId, userId, roleId)).execute();
-    }
-
-    @Override
-    public ActionResponse grantProjectUserRole(String projectId, String userId, String roleId) {
-        checkNotNull(userId);
-        checkNotNull(projectId);
-        checkNotNull(roleId);
-        return put(ActionResponse.class, uri("projects/%s/users/%s/roles/%s", projectId, userId, roleId)).execute();
-    }
-
-    @Override
-    public ActionResponse revokeProjectUserRole(String projectId, String userId, String roleId) {
-        checkNotNull(userId);
-        checkNotNull(projectId);
-        checkNotNull(roleId);
-        return deleteWithResponse(uri("projects/%s/users/%s/roles/%s", projectId, userId, roleId)).execute();
-    }
-
-    @Override
-    public ActionResponse checkDomainUserRole(String domainId, String userId, String roleId) {
-        checkNotNull(domainId);
-        checkNotNull(userId);
-        checkNotNull(roleId);
-        return head(ActionResponse.class, uri("/domains/%s/users/%s/roles/%s", domainId, userId, roleId)).execute();
-    }
-
-    @Override
-    public ActionResponse checkProjectUserRole(String projectId, String userId, String roleId) {
-        checkNotNull(projectId);
-        checkNotNull(userId);
-        checkNotNull(roleId);
-        return head(ActionResponse.class, uri("/projects/%s/users/%s/roles/%s", projectId, userId, roleId)).execute();
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ActionResponse addUserToGroup(String groupId, String userId) {
         checkNotNull(groupId);
@@ -165,13 +159,14 @@ public class UserServiceImpl extends BaseOpenStackService implements UserService
         return put(ActionResponse.class, uri("groups/%s/users/%s", groupId, userId)).execute();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ActionResponse removeUserFromGroup(String groupId, String userId) {
         checkNotNull(groupId);
         checkNotNull(userId);
         return deleteWithResponse(uri("groups/%s/users/%s", groupId, userId)).execute();
     }
-
-
 
 }


### PR DESCRIPTION
Moved the grant/revoke/check-user-role for domain and project context from the userService to the roleService. That would follow the v2-pattern of where this kind of calls should live.
Any comments by @gondor, @dhague ?  