### PR TITLE
Ignore .iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pom-shade.xml
 *.releaseBackup
 *.versionsBackup
 core-integration-test/
+*.iml


### PR DESCRIPTION
Intellij uses .iml files to store information of modules.
It would be good to ignore them to stop Intellij warning about .iml files not under version control.