### PR TITLE
Workaround for buffer overflow with OpenJDK in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,15 @@ language: java
 
 jdk:
   - oraclejdk7
+  - openjdk7
+
+# Workaround for https://github.com/travis-ci/travis-ci/issues/5227
+# Buffer overflow in Java_java_net_Inet4AddressImpl_getLocalHostName
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
 
 notifications:
   email: false


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/5227 for more
information.
This patch should fix the Travis CI errors with OpenJDK.