### PR TITLE
convert boot_index to integer in JSON

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaBlockDeviceMappingCreate.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/domain/NovaBlockDeviceMappingCreate.java
@@ -17,7 +17,7 @@ public class NovaBlockDeviceMappingCreate implements BlockDeviceMappingCreate {
 	public BDMSourceType source_type = BDMSourceType.VOLUME;
 	public BDMDestType destination_type = BDMDestType.VOLUME;
 	public String uuid;
-	public String boot_index;
+	public Integer boot_index;
 	public Integer volume_size;
 	public boolean delete_on_termination = false;
 
@@ -59,7 +59,7 @@ public class NovaBlockDeviceMappingCreate implements BlockDeviceMappingCreate {
 
 		@Override
 		public BlockDeviceMappingBuilder bootIndex(int i) {
-			create.boot_index = String.valueOf(i);
+			create.boot_index = i;
 			return this;
 		}
 


### PR DESCRIPTION
This PR solves #567. The root cause is that OpenStack check boot_index == 0:

```
if not (image_uuid_specified and boot_index == 0):
                  raise exception.InvalidBDMFormat(
                         details=_("Mapping image to local is not supported."))
```

https://github.com/openstack/nova/commit/cadbcc440a2fcfb8532f38111999a06557fbafc2#diff-16c3690d30123cdcd3a1dca53021513aR201