### PR TITLE
Use Travis CI container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,6 @@ jdk:
   - oraclejdk7
   - openjdk7
 
-# Workaround for https://github.com/travis-ci/travis-ci/issues/5227
-# Buffer overflow in Java_java_net_Inet4AddressImpl_getLocalHostName
-before_install:
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
-
 notifications:
   email: false
 
@@ -19,3 +11,8 @@ notifications:
 branches:
   only:
     - master
+
+# disable sudo to ensure that this build runs on the travis container-based
+# infrastructure. This should prevent the buffer overflow from
+# https://github.com/travis-ci/travis-ci/issues/5227
+sudo: false


### PR DESCRIPTION
Remove workaround for Travis CI bug https://github.com/travis-ci/travis-ci/issues/5227 and disable sudo to ensure builds run on the travis container-based infratsructure, where the bug described in above link should not occur.