### PR TITLE
Embeded jackson-dataformat-yaml as a non-OSGi jar dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,6 +74,7 @@
 						</Private-Package>
 						<Import-Package>
 							!org.openstack*,
+							!com.fasterxml.jackson.dataformat.yaml.snakeyaml,
 							*
 						</Import-Package>
 						<!-- 
@@ -98,6 +99,12 @@
 						<Provide-Capability>
 							osgi.serviceloader; osgi.serviceloader=org.openstack4j.api.APIProvider
 						</Provide-Capability>
+						<Embed-Transitive>
+							true
+						</Embed-Transitive>
+						<Embed-Dependency>
+							jackson-dataformat-yaml
+						</Embed-Dependency>
 					</instructions>
 				</configuration>
 			</plugin> 


### PR DESCRIPTION
Fixed unresolved constraint issue when bundling openstack4j in OSGi environment by embedding jackson-dataformat-yaml as a non-OSGi jar dependency.