### PR TITLE
Added noGateway method to the subnet builder

### DIFF
--- a/core/src/main/java/org/openstack4j/model/network/builder/SubnetBuilder.java
+++ b/core/src/main/java/org/openstack4j/model/network/builder/SubnetBuilder.java
@@ -68,6 +68,11 @@ public interface SubnetBuilder extends Builder<SubnetBuilder, Subnet> {
     SubnetBuilder gateway(String gateway);
 
     /**
+     * @see Subnet#isNoGateway()
+     */
+    SubnetBuilder noGateway();
+
+    /**
      * @see Subnet#getDnsNames()
      */
 	SubnetBuilder addDNSNameServer(String host);


### PR DESCRIPTION
Using noGateway method will build a slightly different NeutronSubnet, the only one difference is the property gateway_ip annotated with @JsonInclude to force serialization also if the value is null.
This change will let you add a subnet with gateway disabled.