### PR TITLE
A fix regarding connection leak problem #579

### DIFF
--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
@@ -171,16 +171,18 @@ public class ServerServiceImpl extends BaseComputeServices implements ServerServ
         checkNotNull(snapshotName);
 
         HttpResponse response = invokeActionWithResponse(serverId, CreateSnapshotAction.create(snapshotName));
+        String id = null;
         if (response.getStatus() == 202) {
             String location = response.header("location");
             if (location != null && location.contains("/"))
             {
                 String[] s = location.split("/");
-                return s[s.length - 1];
+                id = s[s.length - 1];
             }
 
         }
-        return null;
+        response.getEntity(Void.class);
+        return id;
     }
 
     /**


### PR DESCRIPTION
In case of http call with response, the returned entity should be consumed in order to release the resources associated with the call, and especially the http connection.

I am not sure where is the right place to consume and release the entity. I made a fix for my use-case - create snapshot, but most probably the this fix is applicable for more situations.