### PR TITLE
identity v3 token service

### DIFF
--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneTokenServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneTokenServiceSpec.groovy
@@ -1,0 +1,105 @@
+package org.openstack4j.api.identity
+
+import org.junit.Rule;
+import org.junit.rules.TestName;
+import org.openstack4j.api.OSClient
+import org.openstack4j.model.compute.ActionResponse
+import org.openstack4j.model.common.Identifier
+import org.openstack4j.model.identity.Token
+import org.openstack4j.openstack.OSFactory
+import org.openstack4j.openstack.internal.OSClientSession
+
+import spock.lang.IgnoreIf
+import co.freeside.betamax.Recorder
+import co.freeside.betamax.Betamax
+import java.util.logging.Logger
+import org.openstack4j.core.transport.Config
+import org.openstack4j.core.transport.ProxyHost
+
+
+
+class KeystoneTokenServiceSpec extends AbstractSpec {
+
+    @Rule TestName KeystoneTokenServiceTest
+    @Rule Recorder recorder = new Recorder(tapeRoot: new File(TAPEROOT))
+
+    // additional attributes for token service tests
+    // Unfortunately betamax stops us from generating a second USER_TOKEN (not able to record and play back) so a fixed token id is provided here.
+    def static final String USER_TOKEN_ID = "fc0fb8dc13994aa7b539279e4b7a304b"
+    def String ADMIN_TOKEN_ID
+
+    static final boolean skipTest
+
+    static {
+        if(
+        USER_ID == null ||
+        AUTH_URL == null ||
+        PASSWORD == null ||
+        DOMAIN_ID == null ||
+        PROJECT_ID == null ) {
+
+            skipTest = true
+        }
+        else{
+            skipTest = false
+        }
+    }
+
+    def setupSpec() {
+
+        if( skipTest != true ) {
+            Logger.getLogger(this.class.name).info("USER_ID: " + USER_ID)
+            Logger.getLogger(this.class.name).info("AUTH_URL: " + AUTH_URL)
+            Logger.getLogger(this.class.name).info("PASSWORD: " + PASSWORD)
+            Logger.getLogger(this.class.name).info("DOMAIN_ID: " + DOMAIN_ID)
+            Logger.getLogger(this.class.name).info("PROJECT_ID: " + PROJECT_ID)
+        }
+        else {
+            Logger.getLogger(this.class.name).warning("Skipping integration-test cases because not all mandatory attributes are set.")
+        }
+    }
+
+    def setup() {
+        Logger.getLogger(this.class.name).info("-> Test: '$KeystoneTokenServiceTest.methodName'")
+    }
+
+
+    // ------------ TokenService Tests ------------
+
+    @IgnoreIf({ skipTest })
+    @Betamax(tape="tokenService_crud.tape")
+    def "create, read, update, delete token-service test cases"() {
+
+        given: "authenticated OSClient"
+        OSClient os = OSFactory.builder()
+                .endpoint(AUTH_URL)
+                .credentials(USER_ID, PASSWORD)
+                .scopeToDomain(Identifier.byId(DOMAIN_ID))
+                .withConfig(CONFIG_PROXY_BETAMAX)
+                .authenticate()
+
+        and: "getting the id of the token used in the current session which has a different id"
+        ADMIN_TOKEN_ID = os.getToken().getId()
+        ADMIN_TOKEN_ID != USER_TOKEN_ID
+
+        when: "validate and get details on an existing token"
+        Token token = os.identity().tokens().get(USER_TOKEN_ID)
+
+        then: "verify the token"
+        token.getDomain().getId() == DOMAIN_ID
+        token.getUser().getId() == USER_ID
+
+        when: "validate an existing, valid token"
+        ActionResponse response_tokenCheck_success = os.identity().tokens().check(USER_TOKEN_ID)
+
+        then: "this should be successful"
+        response_tokenCheck_success.isSuccess() == true
+
+        when: "deleting an existing token"
+        ActionResponse response_tokenDelete_success = os.identity().tokens().delete(USER_TOKEN_ID)
+
+        then: "the token should be successfully deleted"
+        response_tokenDelete_success.isSuccess() == true
+
+    }
+}

--- a/core-integration-test/src/test/resources/tapes/tokenService_crud_tape.yaml
+++ b/core-integration-test/src/test/resources/tapes/tokenService_crud_tape.yaml
@@ -1,0 +1,131 @@
+!tape
+name: tokenService_crud.tape
+interactions:
+- recorded: 2016-03-17T15:38:43.294Z
+  request:
+    method: POST
+    uri: http://devstack.openstack.stack:5000/v3/auth/tokens
+    headers:
+      Accept: application/json
+      Content-Length: '327'
+      Content-Type: application/json
+      Host: devstack.openstack.stack:5000
+      OS4J-Auth-Command: Tokens
+      Proxy-Connection: keep-alive
+      User-Agent: Jersey/2.22.1 (HttpUrlConnection 1.8.0_66)
+    body: |-
+      {
+        "auth" : {
+          "identity" : {
+            "password" : {
+              "user" : {
+                "id" : "71a7dcb0d60a43088a6c8e9b69a39e69",
+                "password" : "devstack"
+              }
+            },
+            "methods" : [ "password" ]
+          },
+          "scope" : {
+            "domain" : {
+              "id" : "default"
+            }
+          },
+          "type" : "CREDENTIALS"
+        }
+      }
+  response:
+    status: 201
+    headers:
+      Content-Type: application/json
+      Date: Thu, 17 Mar 2016 15:38:43 GMT
+      Server: Apache/2.4.7 (Ubuntu)
+      Vary: X-Auth-Token
+      X-Subject-Token: 68422913e9454a9d848e879b1bd786bb
+      x-openstack-request-id: req-c1dca7f8-d2b1-4d80-b622-3f6f058384be
+    body: '{"token": {"domain": {"id": "default", "name": "Default"}, "methods": ["password"], "roles": [{"id": "aae88952465d4c32b0a1140a76601b68", "name": "admin"}], "expires_at": "2016-03-17T16:38:43.256221Z", "catalog": [{"endpoints": [{"region_id": "RegionOne",
+      "url": "http://devstack.openstack.stack:8773/", "region": "RegionOne", "interface": "internal", "id": "1986b6750b784f88a0f1f1e83e511df8"}, {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8773/", "region": "RegionOne", "interface": "admin", "id": "64afe603967b4fd5880792840c659a4d"},
+      {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:8773/", "region": "RegionOne", "interface": "public", "id": "eb3e556f4e2c446e907524447cbb8a5d"}], "type": "ec2", "id": "057b697545694c22b3d20bfe95a2cd7d", "name": "ec2"}, {"endpoints": [], "type": "compute",
+      "id": "110b628369654c83bb58c573df7f88c6", "name": "nova"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region": "RegionOne", "interface": "admin", "id": "3dc90fc97a944ea8abad75fced928309"}, {"region_id": "RegionOne",
+      "url": "http://devstack.openstack.stack:5000/v3", "region": "RegionOne", "interface": "internal", "id": "96fd251f12d34b4caaa76ea1cf446e60"}, {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region": "RegionOne", "interface": "public", "id": "c9f80cc1e5bb4f41a2dc50901cbdd10a"}],
+      "type": "identityv3", "id": "1b565419e6db4407a3f28f5f851db660", "name": "identity v3"}, {"endpoints": [], "type": "volume", "id": "2fb3cbed8edc490788c0c1506e8b0df9", "name": "cinder"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292",
+      "region": "RegionOne", "interface": "internal", "id": "2f5705dddce94d68a41c8370ed09164d"}, {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne", "interface": "admin", "id": "4207a5966c7a46f9b957007a0bbc2d47"}, {"region_id":
+      "RegionOne", "url": "http://devstack.openstack.stack:9292", "region": "RegionOne", "interface": "public", "id": "5ad3ac18eaf64734b53ac33ad0ad0b9e"}], "type": "image", "id": "35815a28b22e48f9bdaadd7df6224a08", "name": "glance"}, {"endpoints": [{"region_id": "RegionOne",
+      "url": "http://devstack.openstack.stack:5000/v3", "region": "RegionOne", "interface": "internal", "id": "a271423a013c470b855d905f30dc5ace"}, {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:5000/v3", "region": "RegionOne", "interface": "public", "id": "cc5c15d1c8b545a2a6401d0078d8b4d4"},
+      {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:35357/v3", "region": "RegionOne", "interface": "admin", "id": "df30fdbb857849009b5174a79672279c"}], "type": "identity", "id": "4f6be6e9c0e74f089985adbf4dbbdb5d", "name": "keystone"}, {"endpoints": [],
+      "type": "volumev2", "id": "7969902dd21744ddbf8fa39a2d53a25e", "name": "cinderv2"}, {"endpoints": [], "type": "identity", "id": "9979eb59328d4af7982d175906735751", "name": "Service_CRUD"}, {"endpoints": [], "type": "computev21", "id": "c7ab57ad5cca470893bad70a4d5bf3ee",
+      "name": "novav21"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface": "public", "id": "0af60b8c25bb43a3900e3965b22f7458"}, {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9696/", "region":
+      "RegionOne", "interface": "admin", "id": "523f2db6ab7542ad8d0cfb67a4a45c1e"}, {"region_id": "RegionOne", "url": "http://devstack.openstack.stack:9696/", "region": "RegionOne", "interface": "internal", "id": "c86b9137fe3a49d58ad027581f7005a7"}], "type": "network", "id":
+      "f6028c7a65c14663946bfeb37c5477ca", "name": "neutron"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id": "71a7dcb0d60a43088a6c8e9b69a39e69", "name": "admin"}, "audit_ids": ["Lx8sPwd-SGS-KO_z7j3Q9w"], "issued_at": "2016-03-17T15:38:43.256251Z"}}'
+- recorded: 2016-03-17T15:38:43.375Z
+  request:
+    method: GET
+    uri: http://devstack.openstack.stack:5000/v3/auth/tokens
+    headers:
+      Accept: application/json
+      Host: devstack.openstack.stack:5000
+      Proxy-Connection: keep-alive
+      User-Agent: OpenStack4j / OpenStack Client
+      X-Auth-Token: 68422913e9454a9d848e879b1bd786bb
+      X-Subject-Token: fc0fb8dc13994aa7b539279e4b7a304b
+  response:
+    status: 200
+    headers:
+      Content-Type: application/json
+      Date: Thu, 17 Mar 2016 15:38:43 GMT
+      Server: Apache/2.4.7 (Ubuntu)
+      Vary: X-Auth-Token
+      X-Subject-Token: fc0fb8dc13994aa7b539279e4b7a304b
+      x-openstack-request-id: req-d9aa4486-b294-47e7-ada7-7a0d11568eef
+    body: '{"token": {"domain": {"id": "default", "name": "Default"}, "methods": ["password"], "roles": [{"id": "aae88952465d4c32b0a1140a76601b68", "name": "admin"}], "expires_at": "2016-03-17T16:37:00.175726Z", "catalog": [{"endpoints": [{"url": "http://devstack.openstack.stack:8773/",
+      "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id": "1986b6750b784f88a0f1f1e83e511df8"}, {"url": "http://devstack.openstack.stack:8773/", "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "64afe603967b4fd5880792840c659a4d"},
+      {"url": "http://devstack.openstack.stack:8773/", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id": "eb3e556f4e2c446e907524447cbb8a5d"}], "type": "ec2", "id": "057b697545694c22b3d20bfe95a2cd7d", "name": "ec2"}, {"endpoints": [], "type": "compute",
+      "id": "110b628369654c83bb58c573df7f88c6", "name": "nova"}, {"endpoints": [{"url": "http://devstack.openstack.stack:5000/v3", "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "3dc90fc97a944ea8abad75fced928309"}, {"url": "http://devstack.openstack.stack:5000/v3",
+      "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id": "96fd251f12d34b4caaa76ea1cf446e60"}, {"url": "http://devstack.openstack.stack:5000/v3", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id": "c9f80cc1e5bb4f41a2dc50901cbdd10a"}],
+      "type": "identityv3", "id": "1b565419e6db4407a3f28f5f851db660", "name": "identity v3"}, {"endpoints": [], "type": "volume", "id": "2fb3cbed8edc490788c0c1506e8b0df9", "name": "cinder"}, {"endpoints": [{"url": "http://devstack.openstack.stack:9292", "interface": "internal",
+      "region": "RegionOne", "region_id": "RegionOne", "id": "2f5705dddce94d68a41c8370ed09164d"}, {"url": "http://devstack.openstack.stack:9292", "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "4207a5966c7a46f9b957007a0bbc2d47"}, {"url": "http://devstack.openstack.stack:9292",
+      "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id": "5ad3ac18eaf64734b53ac33ad0ad0b9e"}], "type": "image", "id": "35815a28b22e48f9bdaadd7df6224a08", "name": "glance"}, {"endpoints": [{"url": "http://devstack.openstack.stack:5000/v3", "interface":
+      "internal", "region": "RegionOne", "region_id": "RegionOne", "id": "a271423a013c470b855d905f30dc5ace"}, {"url": "http://devstack.openstack.stack:5000/v3", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id": "cc5c15d1c8b545a2a6401d0078d8b4d4"},
+      {"url": "http://devstack.openstack.stack:35357/v3", "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "id": "df30fdbb857849009b5174a79672279c"}], "type": "identity", "id": "4f6be6e9c0e74f089985adbf4dbbdb5d", "name": "keystone"}, {"endpoints": [],
+      "type": "volumev2", "id": "7969902dd21744ddbf8fa39a2d53a25e", "name": "cinderv2"}, {"endpoints": [], "type": "identity", "id": "9979eb59328d4af7982d175906735751", "name": "Service_CRUD"}, {"endpoints": [], "type": "computev21", "id": "c7ab57ad5cca470893bad70a4d5bf3ee",
+      "name": "novav21"}, {"endpoints": [{"url": "http://devstack.openstack.stack:9696/", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "id": "0af60b8c25bb43a3900e3965b22f7458"}, {"url": "http://devstack.openstack.stack:9696/", "interface": "admin", "region":
+      "RegionOne", "region_id": "RegionOne", "id": "523f2db6ab7542ad8d0cfb67a4a45c1e"}, {"url": "http://devstack.openstack.stack:9696/", "interface": "internal", "region": "RegionOne", "region_id": "RegionOne", "id": "c86b9137fe3a49d58ad027581f7005a7"}], "type": "network",
+      "id": "f6028c7a65c14663946bfeb37c5477ca", "name": "neutron"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id": "71a7dcb0d60a43088a6c8e9b69a39e69", "name": "admin"}, "audit_ids": ["uyWa_Vp7TfeyrJl-Jd-uMw"], "issued_at": "2016-03-17T15:37:00.175761Z"}}'
+- recorded: 2016-03-17T15:38:43.441Z
+  request:
+    method: HEAD
+    uri: http://devstack.openstack.stack:5000/v3/auth/tokens
+    headers:
+      Accept: application/json
+      Host: devstack.openstack.stack:5000
+      Proxy-Connection: keep-alive
+      User-Agent: OpenStack4j / OpenStack Client
+      X-Auth-Token: 68422913e9454a9d848e879b1bd786bb
+      X-Subject-Token: fc0fb8dc13994aa7b539279e4b7a304b
+  response:
+    status: 200
+    headers:
+      Content-Type: application/json
+      Date: Thu, 17 Mar 2016 15:38:43 GMT
+      Server: Apache/2.4.7 (Ubuntu)
+      Vary: X-Auth-Token
+      X-Betamax: PLAY
+      X-Subject-Token: fc0fb8dc13994aa7b539279e4b7a304b
+      x-openstack-request-id: req-0f239767-43e0-4fed-a940-85290b44dc63
+- recorded: 2016-03-17T15:38:43.522Z
+  request:
+    method: DELETE
+    uri: http://devstack.openstack.stack:5000/v3/auth/tokens
+    headers:
+      Accept: application/json
+      Host: devstack.openstack.stack:5000
+      Proxy-Connection: keep-alive
+      User-Agent: OpenStack4j / OpenStack Client
+      X-Auth-Token: 68422913e9454a9d848e879b1bd786bb
+      X-Subject-Token: fc0fb8dc13994aa7b539279e4b7a304b
+  response:
+    status: 204
+    headers:
+      Date: Thu, 17 Mar 2016 15:38:43 GMT
+      Server: Apache/2.4.7 (Ubuntu)
+      Vary: X-Auth-Token
+      x-openstack-request-id: req-23bc5b15-1a2c-41de-b919-d4ee566c9886

--- a/core/src/main/java/org/openstack4j/api/identity/IdentityService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/IdentityService.java
@@ -39,9 +39,16 @@ public interface IdentityService extends RestService {
     /**
      * Group Service API
      *
-     * @return thr group service
+     * @return the group service
      */
     GroupService groups();
+    
+    /**
+     * Token Service API
+     * 
+     * @return the token service
+     */
+    TokenService tokens();
 
     /**
      * Policy Service API

--- a/core/src/main/java/org/openstack4j/api/identity/TokenService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/TokenService.java
@@ -1,0 +1,36 @@
+package org.openstack4j.api.identity;
+
+import org.openstack4j.common.RestService;
+import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.identity.Token;
+
+/**
+ * Identity V3 Token operations
+ *
+ */
+public interface TokenService extends RestService {
+    
+    /***
+     * Validates and shows information for a token.
+     * 
+     * @param tokenId the identifier of the token that is subject to be checked
+     * @return the token if valid
+     */
+    Token get(String tokenId);
+    
+    /**
+     * Validates a token.
+     * 
+     * @param tokenId the identifier of the token that is subject to be checked
+     * @return the ActionResponse
+     */
+    ActionResponse check(String tokenId);
+    
+    /**
+     * Revokes a token.
+     * 
+     * @param tokenId the identifier of the token that is going to be deleted
+     * @return the ActionResponse
+     */
+    ActionResponse delete(String tokenId);    
+}

--- a/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
+++ b/core/src/main/java/org/openstack4j/core/transport/ClientConstants.java
@@ -36,5 +36,6 @@ public final class ClientConstants {
     public static final String PATH_GROUPS = "/groups";
     public static final String PATH_POLICIES = "/policies";
     public static final String PATH_REGIONS = "/regions";
+    public static final String PATH_TOKENS = "/auth/tokens";
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/IdentityServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/IdentityServiceImpl.java
@@ -9,6 +9,7 @@ import org.openstack4j.api.identity.ProjectService;
 import org.openstack4j.api.identity.RegionService;
 import org.openstack4j.api.identity.RoleService;
 import org.openstack4j.api.identity.ServiceEndpointService;
+import org.openstack4j.api.identity.TokenService;
 import org.openstack4j.api.identity.UserService;
 import org.openstack4j.openstack.internal.BaseOpenStackService;
 
@@ -28,26 +29,26 @@ public class IdentityServiceImpl extends BaseOpenStackService implements Identit
         return Apis.get(ProjectService.class);
     }
 
-	@Override
-	public UserService users() {
-		return Apis.get(UserService.class);
-	}
+    @Override
+    public UserService users() {
+        return Apis.get(UserService.class);
+    }
 
-	@Override
-	public RoleService roles() {
-		return Apis.get(RoleService.class);
-	}
+    @Override
+    public RoleService roles() {
+        return Apis.get(RoleService.class);
+    }
 
     @Override
     public GroupService groups() {
         return Apis.get(GroupService.class);
     }
-    
+
     @Override
     public PolicyService policies() {
         return Apis.get(PolicyService.class);
     }
-    
+
     @Override
     public ServiceEndpointService serviceEndpoints() {
         return Apis.get(ServiceEndpointService.class);
@@ -56,6 +57,11 @@ public class IdentityServiceImpl extends BaseOpenStackService implements Identit
     @Override
     public RegionService regions() {
         return Apis.get(RegionService.class);
+    }
+
+    @Override
+    public TokenService tokens() {
+        return Apis.get(TokenService.class);
     }
 
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/TokenServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/TokenServiceImpl.java
@@ -1,0 +1,33 @@
+package org.openstack4j.openstack.identity.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.openstack4j.core.transport.ClientConstants.PATH_TOKENS;
+import static org.openstack4j.core.transport.ClientConstants.HEADER_X_SUBJECT_TOKEN;
+
+import org.openstack4j.api.identity.TokenService;
+import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.identity.Token;
+import org.openstack4j.openstack.identity.domain.KeystoneToken;
+import org.openstack4j.openstack.internal.BaseOpenStackService;
+
+public class TokenServiceImpl extends BaseOpenStackService implements TokenService {
+
+    @Override
+    public Token get(String tokenId) {
+        checkNotNull(tokenId);
+        return get(KeystoneToken.class, PATH_TOKENS).header(HEADER_X_SUBJECT_TOKEN, tokenId).execute();
+    }
+
+    @Override
+    public ActionResponse check(String tokenId) {
+        checkNotNull(tokenId);
+        return head(ActionResponse.class, PATH_TOKENS).header(HEADER_X_SUBJECT_TOKEN, tokenId).execute();
+    }
+
+    @Override
+    public ActionResponse delete(String tokenId) {
+        checkNotNull(tokenId);
+        return deleteWithResponse(PATH_TOKENS).header(HEADER_X_SUBJECT_TOKEN, tokenId).execute();
+    }
+
+}

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -29,8 +29,6 @@ import com.google.common.base.Joiner;
 
 public class BaseOpenStackService {
 
-
-
     ServiceType serviceType = ServiceType.IDENTITY;
     Function<String, String> endpointFunc;
 
@@ -78,8 +76,9 @@ public class BaseOpenStackService {
         return builder(returnType, path, method);
     }
 
-    protected String uri(String path, Object...params) {
-        if (params.length == 0) return path;
+    protected String uri(String path, Object... params) {
+        if (params.length == 0)
+            return path;
         return String.format(path, params);
     }
 
@@ -90,16 +89,18 @@ public class BaseOpenStackService {
     private <R> Invocation<R> builder(Class<R> returnType, String path, HttpMethod method) {
         OSClientSession ses = OSClientSession.getCurrent();
         if (ses == null) {
-        	throw new OS4JException("Unable to retrieve current session. Please verify thread has a current session available.");
+            throw new OS4JException(
+                    "Unable to retrieve current session. Please verify thread has a current session available.");
         }
-        RequestBuilder<R> req = HttpRequest.builder(returnType).endpointTokenProvider(ses).config(ses.getConfig()).method(method).path(path);
+        RequestBuilder<R> req = HttpRequest.builder(returnType).endpointTokenProvider(ses).config(ses.getConfig())
+                .method(method).path(path);
         return new Invocation<R>(req, serviceType, endpointFunc);
     }
 
     protected static class Invocation<R> {
-        RequestBuilder<R>  req;
+        RequestBuilder<R> req;
 
-        protected Invocation(RequestBuilder<R>  req, ServiceType serviceType, Function<String, String> endpointFunc) {
+        protected Invocation(RequestBuilder<R> req, ServiceType serviceType, Function<String, String> endpointFunc) {
             this.req = req;
             req.serviceType(serviceType);
             req.endpointFunction(endpointFunc);

--- a/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
+++ b/core/src/main/java/org/openstack4j/openstack/provider/DefaultAPIProvider.java
@@ -64,6 +64,7 @@ public class DefaultAPIProvider implements APIProvider {
         bind(GroupService.class, GroupServiceImpl.class);
         bind(PolicyService.class, PolicyServiceImpl.class);
         bind(RegionService.class, RegionServiceImpl.class);
+        bind(TokenService.class, TokenServiceImpl.class);
         bind(ComputeService.class, ComputeServiceImpl.class);
         bind(FlavorService.class, FlavorServiceImpl.class);
         bind(ComputeImageService.class, ComputeImageServiceImpl.class);


### PR DESCRIPTION
This addresses #540 and brings the missing token- check(), validate() and revoke() methods.


Note: This PR introduces the last service for the identity v3 part. The next PR should be the final before one before the release which will focus on the v2/v3 compatibility.

What do you think @gondor and @dhague ?