### PR TITLE
Move ActionResponse into common package

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/compute/FloatingIPTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/FloatingIPTests.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.core.transport.internal.HttpExecutor;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.FloatingIP;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;

--- a/core-test/src/main/java/org/openstack4j/api/manila/QuotaSetTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/QuotaSetTests.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.api.AbstractTest;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.QuotaSet;
 import org.openstack4j.model.manila.QuotaSetUpdateOptions;
 import org.testng.annotations.Test;

--- a/core-test/src/main/java/org/openstack4j/api/manila/SecurityServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/SecurityServiceTests.java
@@ -2,7 +2,7 @@ package org.openstack4j.api.manila;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.SecurityService;
 import org.openstack4j.model.manila.SecurityServiceCreate;
 import org.openstack4j.model.manila.SecurityServiceUpdateOptions;

--- a/core-test/src/main/java/org/openstack4j/api/manila/ShareInstanceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/ShareInstanceTests.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.api.AbstractTest;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareInstance;
 import org.testng.annotations.Test;
 

--- a/core-test/src/main/java/org/openstack4j/api/manila/ShareNetworkTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/ShareNetworkTests.java
@@ -2,7 +2,7 @@ package org.openstack4j.api.manila;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareNetwork;
 import org.openstack4j.model.manila.ShareNetworkCreate;
 import org.openstack4j.model.manila.ShareNetworkUpdateOptions;

--- a/core-test/src/main/java/org/openstack4j/api/manila/ShareServerTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/ShareServerTests.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.api.AbstractTest;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareServer;
 import org.testng.annotations.Test;
 

--- a/core-test/src/main/java/org/openstack4j/api/manila/ShareSnapshotTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/ShareSnapshotTests.java
@@ -2,7 +2,7 @@ package org.openstack4j.api.manila;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.Share;
 import org.openstack4j.model.manila.ShareSnapshot;
 import org.openstack4j.model.manila.ShareSnapshotCreate;

--- a/core-test/src/main/java/org/openstack4j/api/manila/ShareTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/ShareTests.java
@@ -4,7 +4,7 @@ import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
 import org.openstack4j.core.transport.HttpMethod;
 import org.openstack4j.model.common.Extension;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.*;
 import org.openstack4j.openstack.manila.domain.ManilaService;
 import org.testng.annotations.Test;

--- a/core-test/src/main/java/org/openstack4j/api/manila/ShareTypeTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/ShareTypeTests.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.manila;
 import com.beust.jcommander.internal.Maps;
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ExtraSpecs;
 import org.openstack4j.model.manila.ShareType;
 import org.openstack4j.model.manila.ShareTypeAccess;

--- a/core-test/src/main/java/org/openstack4j/api/manila/SharesTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/manila/SharesTests.java
@@ -2,7 +2,7 @@ package org.openstack4j.api.manila;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.Access;
 import org.openstack4j.model.manila.Share;
 import org.openstack4j.model.manila.ShareCreate;

--- a/core-test/src/main/java/org/openstack4j/api/network/HealthMonitorTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/HealthMonitorTests.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.HealthMonitor;
 import org.openstack4j.model.network.ext.HealthMonitorType;
 import org.openstack4j.model.network.ext.HealthMonitorUpdate;

--- a/core-test/src/main/java/org/openstack4j/api/network/LbPoolTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/LbPoolTests.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.HealthMonitor;
 import org.openstack4j.model.network.ext.HealthMonitorAssociate;
 import org.openstack4j.model.network.ext.LbMethod;

--- a/core-test/src/main/java/org/openstack4j/api/network/MemberTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/MemberTests.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Member;
 import org.openstack4j.model.network.ext.MemberUpdate;
 import org.testng.annotations.Test;

--- a/core-test/src/main/java/org/openstack4j/api/network/VipTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/VipTests.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Protocol;
 import org.openstack4j.model.network.ext.SessionPersistenceType;
 import org.openstack4j.model.network.ext.Vip;

--- a/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallPolicyTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallPolicyTests.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.FirewallPolicy;
 import org.openstack4j.model.network.ext.FirewallPolicyUpdate;
 import org.openstack4j.openstack.networking.domain.ext.FirewallRuleStrategy.RuleInsertStrategyType;

--- a/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallRuleTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallRuleTests.java
@@ -10,7 +10,7 @@ import java.util.logging.Logger;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.IPVersionType;
 import org.openstack4j.model.network.ext.FirewallRule;
 import org.openstack4j.model.network.ext.FirewallRuleUpdate;

--- a/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/firewalls/FirewallTests.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Firewall;
 import org.openstack4j.model.network.ext.FirewallUpdate;
 import org.openstack4j.openstack.networking.domain.ext.NeutronFirewall.FirewallStatus;

--- a/core/src/main/java/org/openstack4j/api/compute/ComputeFloatingIPService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeFloatingIPService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.compute;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.FloatingIP;
 import org.openstack4j.model.compute.Server;
 

--- a/core/src/main/java/org/openstack4j/api/compute/ComputeImageService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeImageService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Image;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/compute/ComputeSecurityGroupService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ComputeSecurityGroupService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.compute;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.SecGroupExtension;
 import org.openstack4j.model.compute.SecGroupExtension.Rule;
 

--- a/core/src/main/java/org/openstack4j/api/compute/FlavorService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/FlavorService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Flavor;
 import org.openstack4j.model.compute.FlavorAccess;
 

--- a/core/src/main/java/org/openstack4j/api/compute/HostAggregateService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/HostAggregateService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.compute;
 import java.util.List;
 import java.util.Map;
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.HostAggregate;
 /**
  * Host aggregate Operations API

--- a/core/src/main/java/org/openstack4j/api/compute/KeypairService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/KeypairService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Keypair;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/compute/ServerGroupService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ServerGroupService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.compute;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.ServerGroup;
 
 public interface ServerGroupService extends RestService {

--- a/core/src/main/java/org/openstack4j/api/compute/ServerService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ServerService.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.openstack4j.api.compute.ext.InterfaceService;
 import org.openstack4j.model.compute.Action;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.RebootType;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.Server.Status;

--- a/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSDomainService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSDomainService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.compute.ext;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.ext.DomainEntry;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSEntryService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ext/FloatingIPDNSEntryService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.compute.ext;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.ext.DNSEntry;
 import org.openstack4j.model.compute.ext.DNSRecordType;
 

--- a/core/src/main/java/org/openstack4j/api/compute/ext/InterfaceService.java
+++ b/core/src/main/java/org/openstack4j/api/compute/ext/InterfaceService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.compute.ext;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.InterfaceAttachment;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/heat/SoftwareConfigService.java
+++ b/core/src/main/java/org/openstack4j/api/heat/SoftwareConfigService.java
@@ -2,7 +2,7 @@ package org.openstack4j.api.heat;
 
 import org.openstack4j.api.Builders;
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.heat.SoftwareConfig;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/heat/StackService.java
+++ b/core/src/main/java/org/openstack4j/api/heat/StackService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.heat;
 import java.util.List;
 import java.util.Map;
 
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.heat.Stack;
 import org.openstack4j.model.heat.StackCreate;
 import org.openstack4j.model.heat.StackUpdate;

--- a/core/src/main/java/org/openstack4j/api/identity/RoleService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/RoleService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.identity;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Role;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/identity/ServiceManagerService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/ServiceManagerService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.identity;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Service;
 import org.openstack4j.model.identity.ServiceEndpoint;
 

--- a/core/src/main/java/org/openstack4j/api/identity/TenantService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/TenantService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.identity;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Tenant;
 import org.openstack4j.model.identity.TenantUser;
 

--- a/core/src/main/java/org/openstack4j/api/identity/UserService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/UserService.java
@@ -2,7 +2,7 @@ package org.openstack4j.api.identity;
 
 import java.util.List;
 
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Role;
 import org.openstack4j.model.identity.User;
 

--- a/core/src/main/java/org/openstack4j/api/image/ImageService.java
+++ b/core/src/main/java/org/openstack4j/api/image/ImageService.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.common.Payload;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.image.Image;
 import org.openstack4j.model.image.ImageMember;
 

--- a/core/src/main/java/org/openstack4j/api/manila/QuotaSetService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/QuotaSetService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.QuotaSet;
 import org.openstack4j.model.manila.QuotaSetUpdateOptions;
 

--- a/core/src/main/java/org/openstack4j/api/manila/SecurityServiceService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/SecurityServiceService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.SecurityService;
 import org.openstack4j.model.manila.SecurityServiceCreate;
 import org.openstack4j.model.manila.SecurityServiceUpdateOptions;

--- a/core/src/main/java/org/openstack4j/api/manila/ShareInstanceService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareInstanceService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareInstance;
 
 import java.util.List;

--- a/core/src/main/java/org/openstack4j/api/manila/ShareNetworkService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareNetworkService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareNetwork;
 import org.openstack4j.model.manila.ShareNetworkCreate;
 import org.openstack4j.model.manila.ShareNetworkUpdateOptions;

--- a/core/src/main/java/org/openstack4j/api/manila/ShareServerService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareServerService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareServer;
 
 import java.util.List;

--- a/core/src/main/java/org/openstack4j/api/manila/ShareService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareService.java
@@ -2,7 +2,7 @@ package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.common.Extension;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.*;
 import org.openstack4j.openstack.manila.domain.ManilaService;
 

--- a/core/src/main/java/org/openstack4j/api/manila/ShareSnapshotService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareSnapshotService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareSnapshot;
 import org.openstack4j.model.manila.ShareSnapshotCreate;
 import org.openstack4j.model.manila.ShareSnapshotUpdateOptions;

--- a/core/src/main/java/org/openstack4j/api/manila/ShareTypeService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/ShareTypeService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ExtraSpecs;
 import org.openstack4j.model.manila.ShareType;
 import org.openstack4j.model.manila.ShareTypeAccess;

--- a/core/src/main/java/org/openstack4j/api/manila/SharesService.java
+++ b/core/src/main/java/org/openstack4j/api/manila/SharesService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.manila;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.Access;
 import org.openstack4j.model.manila.Share;
 import org.openstack4j.model.manila.ShareCreate;

--- a/core/src/main/java/org/openstack4j/api/networking/NetFloatingIPService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/NetFloatingIPService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.NetFloatingIP;
 
 

--- a/core/src/main/java/org/openstack4j/api/networking/NetworkService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/NetworkService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.openstack4j.api.Builders;
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.network.NetworkUpdate;
 

--- a/core/src/main/java/org/openstack4j/api/networking/PortService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/PortService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.networking;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Port;
 import org.openstack4j.model.network.options.PortListOptions;
 

--- a/core/src/main/java/org/openstack4j/api/networking/RouterService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/RouterService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.networking;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.AttachInterfaceType;
 import org.openstack4j.model.network.Router;
 import org.openstack4j.model.network.RouterInterface;

--- a/core/src/main/java/org/openstack4j/api/networking/SecurityGroupService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/SecurityGroupService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.networking;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.SecurityGroup;
 
 

--- a/core/src/main/java/org/openstack4j/api/networking/SubnetService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/SubnetService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.networking;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Subnet;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/networking/ext/FirewallPolicyService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/FirewallPolicyService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.FirewallPolicy;
 import org.openstack4j.model.network.ext.FirewallPolicyUpdate;
 import org.openstack4j.openstack.networking.domain.ext.FirewallRuleStrategy.RuleInsertStrategyType;

--- a/core/src/main/java/org/openstack4j/api/networking/ext/FirewallRuleService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/FirewallRuleService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.FirewallRule;
 import org.openstack4j.model.network.ext.FirewallRuleUpdate;
 

--- a/core/src/main/java/org/openstack4j/api/networking/ext/FirewallService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/FirewallService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Firewall;
 import org.openstack4j.model.network.ext.FirewallUpdate;
 

--- a/core/src/main/java/org/openstack4j/api/networking/ext/HealthMonitorService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/HealthMonitorService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.networking.ext;
 import java.util.List;
 import java.util.Map;
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.HealthMonitor;
 import org.openstack4j.model.network.ext.HealthMonitorUpdate;
 /**

--- a/core/src/main/java/org/openstack4j/api/networking/ext/LbPoolService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/LbPoolService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.HealthMonitor;
 import org.openstack4j.model.network.ext.HealthMonitorAssociate;
 import org.openstack4j.model.network.ext.LbPool;

--- a/core/src/main/java/org/openstack4j/api/networking/ext/MemberService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/MemberService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Member;
 import org.openstack4j.model.network.ext.MemberUpdate;
 /**

--- a/core/src/main/java/org/openstack4j/api/networking/ext/NetQuotaService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/NetQuotaService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.networking.ext;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.NetQuota;
 import org.openstack4j.model.network.builder.NetQuotaBuilder;
 

--- a/core/src/main/java/org/openstack4j/api/networking/ext/VipService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/VipService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.networking.ext;
 import java.util.List;
 import java.util.Map;
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Vip;
 import org.openstack4j.model.network.ext.VipUpdate;
 /**

--- a/core/src/main/java/org/openstack4j/api/sahara/ClusterService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/ClusterService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.sahara;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.Cluster;
 import org.openstack4j.model.sahara.NodeGroup;
 

--- a/core/src/main/java/org/openstack4j/api/sahara/ClusterTemplateService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/ClusterTemplateService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.sahara;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.ClusterTemplate;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/sahara/DataSourceService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/DataSourceService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.sahara;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.DataSource;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/sahara/JobBinaryInternalService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/JobBinaryInternalService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.common.Payload;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.JobBinaryInternal;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/sahara/JobBinaryService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/JobBinaryService.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.common.Payload;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.JobBinary;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/sahara/JobExecutionService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/JobExecutionService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.sahara;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.JobExecution;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/sahara/JobService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/JobService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.sahara;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.Job;
 import org.openstack4j.model.sahara.JobConfigHint;
 

--- a/core/src/main/java/org/openstack4j/api/sahara/NodeGroupTemplateService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/NodeGroupTemplateService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.sahara;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.NodeGroupTemplate;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/sahara/SaharaImageService.java
+++ b/core/src/main/java/org/openstack4j/api/sahara/SaharaImageService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.sahara;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.Image;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/storage/BlockQuotaSetService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/BlockQuotaSetService.java
@@ -1,7 +1,7 @@
 package org.openstack4j.api.storage;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.BlockQuotaSet;
 import org.openstack4j.model.storage.block.BlockQuotaSetUsage;
 

--- a/core/src/main/java/org/openstack4j/api/storage/BlockVolumeService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/BlockVolumeService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.Volume;
 import org.openstack4j.model.storage.block.VolumeType;
 import org.openstack4j.model.storage.block.VolumeUploadImage;

--- a/core/src/main/java/org/openstack4j/api/storage/BlockVolumeSnapshotService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/BlockVolumeSnapshotService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.VolumeSnapshot;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/storage/BlockVolumeTransferService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/BlockVolumeTransferService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.storage;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.VolumeTransfer;
 
 /**

--- a/core/src/main/java/org/openstack4j/api/storage/ObjectStorageContainerService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/ObjectStorageContainerService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.object.SwiftContainer;
 import org.openstack4j.model.storage.object.options.ContainerListOptions;
 import org.openstack4j.model.storage.object.options.CreateUpdateContainerOptions;

--- a/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.openstack4j.common.RestService;
 import org.openstack4j.model.common.DLPayload;
 import org.openstack4j.model.common.Payload;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.options.DownloadOptions;
 import org.openstack4j.model.storage.object.SwiftObject;
 import org.openstack4j.model.storage.object.options.ObjectListOptions;

--- a/core/src/main/java/org/openstack4j/api/telemetry/AlarmService.java
+++ b/core/src/main/java/org/openstack4j/api/telemetry/AlarmService.java
@@ -3,7 +3,7 @@ package org.openstack4j.api.telemetry;
 import java.util.List;
 
 import org.openstack4j.common.RestService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.telemetry.Alarm;
 
 /**

--- a/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
+++ b/core/src/main/java/org/openstack4j/core/transport/HttpEntityHandler.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 
 import org.openstack4j.api.exceptions.ResponseException;
 import org.openstack4j.core.transport.functions.ResponseToActionResponse;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.openstack.logging.Logger;
 import org.openstack4j.openstack.logging.LoggerFactory;
 

--- a/core/src/main/java/org/openstack4j/core/transport/functions/ParseActionResponseFromJsonMap.java
+++ b/core/src/main/java/org/openstack4j/core/transport/functions/ParseActionResponseFromJsonMap.java
@@ -3,7 +3,7 @@ package org.openstack4j.core.transport.functions;
 import java.util.Map;
 
 import org.openstack4j.core.transport.HttpResponse;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 
 import com.google.common.base.Function;
 

--- a/core/src/main/java/org/openstack4j/core/transport/functions/ResponseToActionResponse.java
+++ b/core/src/main/java/org/openstack4j/core/transport/functions/ResponseToActionResponse.java
@@ -3,7 +3,7 @@ package org.openstack4j.core.transport.functions;
 import java.util.Map;
 
 import org.openstack4j.core.transport.HttpResponse;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.openstack.internal.Parser;
 
 import com.google.common.base.Function;

--- a/core/src/main/java/org/openstack4j/core/transport/propagation/PropagateOnStatus.java
+++ b/core/src/main/java/org/openstack4j/core/transport/propagation/PropagateOnStatus.java
@@ -5,7 +5,7 @@ import static org.openstack4j.core.transport.HttpExceptionHandler.mapException;
 import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.core.transport.PropagateResponse;
 import org.openstack4j.core.transport.functions.ResponseToActionResponse;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 
 /**
  * Propagates an exception based on the specified Status code

--- a/core/src/main/java/org/openstack4j/model/common/ActionResponse.java
+++ b/core/src/main/java/org/openstack4j/model/common/ActionResponse.java
@@ -1,8 +1,8 @@
-package org.openstack4j.model.compute;
-
-import java.io.Serializable;
+package org.openstack4j.model.common;
 
 import com.google.common.base.Objects;
+
+import java.io.Serializable;
 
 /**
  * A response that is returned when an Action is performed against the server.  If {@link #isSuccess()} is true then the fault will always be null. The fault

--- a/core/src/main/java/org/openstack4j/openstack/compute/functions/ToActionResponseFunction.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/functions/ToActionResponseFunction.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.compute.functions;
 import org.openstack4j.core.transport.HttpEntityHandler;
 import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.core.transport.functions.ResponseToActionResponse;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.openstack.logging.Logger;
 import org.openstack4j.openstack.logging.LoggerFactory;
 

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/BaseComputeServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/BaseComputeServices.java
@@ -2,7 +2,7 @@ package org.openstack4j.openstack.compute.internal;
 
 import org.openstack4j.api.types.ServiceType;
 import org.openstack4j.core.transport.HttpResponse;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.openstack.compute.domain.actions.ServerAction;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
 import org.openstack4j.openstack.internal.BaseOpenStackService;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeFloatingIPServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeFloatingIPServiceImpl.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.openstack4j.api.compute.ComputeFloatingIPService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.FloatingIP;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.openstack.common.MapEntity;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeImageServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeImageServiceImpl.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.api.compute.ComputeImageService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Image;
 import org.openstack4j.openstack.compute.domain.MetaDataWrapper;
 import org.openstack4j.openstack.compute.domain.NovaImage;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeSecurityGroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeSecurityGroupServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.compute.ComputeSecurityGroupService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.SecGroupExtension;
 import org.openstack4j.model.compute.SecGroupExtension.Rule;
 import org.openstack4j.openstack.compute.domain.NovaSecGroupExtension;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/FlavorServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/FlavorServiceImpl.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.api.compute.FlavorService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Flavor;
 import org.openstack4j.model.compute.FlavorAccess;
 import org.openstack4j.openstack.compute.domain.ExtraSpecsWrapper;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/HostAggregateServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/HostAggregateServiceImpl.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.openstack4j.api.compute.HostAggregateService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.HostAggregate;
 import org.openstack4j.openstack.compute.domain.AggregateAddHost;
 import org.openstack4j.openstack.compute.domain.AggregateRemoveHost;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/KeypairServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/KeypairServiceImpl.java
@@ -7,7 +7,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import org.openstack4j.api.compute.KeypairService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Keypair;
 import org.openstack4j.openstack.compute.domain.NovaKeypair;
 import org.openstack4j.openstack.compute.domain.NovaKeypair.Keypairs;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerGroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerGroupServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.compute.ServerGroupService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.ServerGroup;
 import org.openstack4j.openstack.compute.domain.NovaServerGroup;
 import org.openstack4j.openstack.compute.domain.NovaServerGroup.ServerGroups;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ServerServiceImpl.java
@@ -14,7 +14,7 @@ import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
 import org.openstack4j.model.compute.Action;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.RebootType;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.Server.Status;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSDomainServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSDomainServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.compute.ext.FloatingIPDNSDomainService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.ext.DomainEntry;
 import org.openstack4j.model.compute.ext.DomainEntry.Scope;
 import org.openstack4j.openstack.compute.domain.ext.ExtDomainEntry;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSEntryServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/FloatingIPDNSEntryServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.compute.ext.FloatingIPDNSEntryService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.ext.DNSEntry;
 import org.openstack4j.model.compute.ext.DNSRecordType;
 import org.openstack4j.openstack.compute.domain.ext.ExtDNSEntry;

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/InterfaceServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ext/InterfaceServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.compute.ext.InterfaceService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.InterfaceAttachment;
 import org.openstack4j.openstack.compute.domain.NovaInterfaceAttachment;
 import org.openstack4j.openstack.compute.domain.NovaInterfaceAttachment.NovaInterfaceAttachments;

--- a/core/src/main/java/org/openstack4j/openstack/heat/internal/SoftwareConfigServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/internal/SoftwareConfigServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.heat.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.openstack4j.api.heat.SoftwareConfigService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.heat.SoftwareConfig;
 import org.openstack4j.openstack.heat.domain.HeatSoftwareConfig;
 

--- a/core/src/main/java/org/openstack4j/openstack/heat/internal/StackServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/internal/StackServiceImpl.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.heat.StackService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.heat.Stack;
 import org.openstack4j.model.heat.StackCreate;
 import org.openstack4j.model.heat.StackUpdate;

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/RoleServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/RoleServiceImpl.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.openstack4j.api.identity.RoleService;
 import org.openstack4j.core.transport.HttpMethod;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Role;
 import org.openstack4j.openstack.identity.domain.KeystoneRole;
 import org.openstack4j.openstack.identity.domain.KeystoneRole.Roles;

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/ServiceManagerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/ServiceManagerServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.identity.ServiceManagerService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Service;
 import org.openstack4j.model.identity.ServiceEndpoint;
 import org.openstack4j.openstack.identity.domain.KeystoneService;

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/TenantServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/TenantServiceImpl.java
@@ -6,7 +6,7 @@ import static org.openstack4j.core.transport.ClientConstants.PATH_TENANTS;
 import java.util.List;
 
 import org.openstack4j.api.identity.TenantService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Tenant;
 import org.openstack4j.model.identity.TenantUser;
 import org.openstack4j.openstack.identity.domain.KeystoneTenant;

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/UserServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/UserServiceImpl.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.openstack4j.api.Apis;
 import org.openstack4j.api.identity.UserService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Role;
 import org.openstack4j.model.identity.User;
 import org.openstack4j.openstack.identity.domain.KeystoneUser;

--- a/core/src/main/java/org/openstack4j/openstack/image/internal/ImageServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/image/internal/ImageServiceImpl.java
@@ -16,7 +16,7 @@ import org.openstack4j.api.image.ImageService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.model.common.Payload;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.image.Image;
 import org.openstack4j.model.image.ImageMember;
 import org.openstack4j.openstack.image.domain.GlanceImage;

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -21,7 +21,7 @@ import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.core.transport.internal.HttpExecutor;
 import org.openstack4j.model.ModelEntity;
 import org.openstack4j.model.common.Payload;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.identity.Access.Service;
 
 import com.google.common.base.Function;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/QuotaSetServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/QuotaSetServiceImpl.java
@@ -1,7 +1,7 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.manila.QuotaSetService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.QuotaSet;
 import org.openstack4j.model.manila.QuotaSetUpdateOptions;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/SecurityServiceServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/SecurityServiceServiceImpl.java
@@ -1,7 +1,7 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.manila.SecurityServiceService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.SecurityService;
 import org.openstack4j.model.manila.SecurityServiceCreate;
 import org.openstack4j.model.manila.SecurityServiceUpdateOptions;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareInstanceServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareInstanceServiceImpl.java
@@ -1,7 +1,7 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.manila.ShareInstanceService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareInstance;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
 import org.openstack4j.openstack.manila.domain.ManilaShareInstance;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareNetworkServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareNetworkServiceImpl.java
@@ -1,7 +1,7 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.manila.ShareNetworkService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareNetwork;
 import org.openstack4j.model.manila.ShareNetworkCreate;
 import org.openstack4j.model.manila.ShareNetworkUpdateOptions;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServerServiceImpl.java
@@ -1,7 +1,7 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.manila.ShareServerService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareServer;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
 import org.openstack4j.openstack.manila.domain.ManilaShareServer;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.manila.internal;
 import org.openstack4j.api.Apis;
 import org.openstack4j.api.manila.*;
 import org.openstack4j.model.common.Extension;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.*;
 import org.openstack4j.openstack.common.ExtensionValue.ManilaExtensions;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareSnapshotServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareSnapshotServiceImpl.java
@@ -1,7 +1,7 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.manila.ShareSnapshotService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ShareSnapshot;
 import org.openstack4j.model.manila.ShareSnapshotCreate;
 import org.openstack4j.model.manila.ShareSnapshotUpdateOptions;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareTypeServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareTypeServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.manila.internal;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.openstack4j.api.manila.ShareTypeService;
 import org.openstack4j.model.ModelEntity;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.ExtraSpecs;
 import org.openstack4j.model.manila.ShareType;
 import org.openstack4j.model.manila.ShareTypeAccess;

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/SharesServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/SharesServiceImpl.java
@@ -1,7 +1,7 @@
 package org.openstack4j.openstack.manila.internal;
 
 import org.openstack4j.api.manila.SharesService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.manila.Access;
 import org.openstack4j.model.manila.Share;
 import org.openstack4j.model.manila.ShareCreate;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/FloatingIPServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/FloatingIPServiceImpl.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.openstack4j.api.networking.NetFloatingIPService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.NetFloatingIP;
 import org.openstack4j.openstack.networking.domain.NeutronFloatingIP;
 import org.openstack4j.openstack.networking.domain.NeutronFloatingIP.FloatingIPs;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/NetworkServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.networking.NetworkService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.network.NetworkUpdate;
 import org.openstack4j.openstack.networking.domain.NeutronNetwork;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/PortServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/PortServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.networking.PortService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Port;
 import org.openstack4j.model.network.options.PortListOptions;
 import org.openstack4j.openstack.networking.domain.NeutronPort;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/RouterServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/RouterServiceImpl.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.openstack4j.api.networking.RouterService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.AttachInterfaceType;
 import org.openstack4j.model.network.HostRoute;
 import org.openstack4j.model.network.Router;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/SecurityGroupServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.networking.SecurityGroupService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.SecurityGroup;
 import org.openstack4j.openstack.networking.domain.NeutronSecurityGroup;
 import org.openstack4j.openstack.networking.domain.NeutronSecurityGroup.SecurityGroups;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/SubnetServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/SubnetServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.networking.SubnetService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Subnet;
 import org.openstack4j.openstack.networking.domain.NeutronSubnet;
 import org.openstack4j.openstack.networking.domain.NeutronSubnet.Subnets;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallPolicyServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallPolicyServiceImpl.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.openstack4j.api.networking.ext.FirewallPolicyService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.FirewallPolicy;
 import org.openstack4j.model.network.ext.FirewallPolicyUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallRuleServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallRuleServiceImpl.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.openstack4j.api.networking.ext.FirewallRuleService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.FirewallRule;
 import org.openstack4j.model.network.ext.FirewallRuleUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/FirewallServiceImpl.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.openstack4j.api.networking.ext.FirewallService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Firewall;
 import org.openstack4j.model.network.ext.FirewallUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/HealthMonitorServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/HealthMonitorServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 import java.util.Map;
 import org.openstack4j.api.networking.ext.HealthMonitorService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.HealthMonitor;
 import org.openstack4j.model.network.ext.HealthMonitorUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/LbPoolServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/LbPoolServiceImpl.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.networking.ext.LbPoolService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.HealthMonitor;
 import org.openstack4j.model.network.ext.HealthMonitorAssociate;
 import org.openstack4j.model.network.ext.LbPool;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/MemberServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/MemberServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.networking.internal.ext;
 import java.util.List;
 import java.util.Map;
 import org.openstack4j.api.networking.ext.MemberService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Member;
 import org.openstack4j.model.network.ext.MemberUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/NetQuotaServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/NetQuotaServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.networking.internal.ext;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.openstack4j.api.networking.ext.NetQuotaService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.NetQuota;
 import org.openstack4j.openstack.networking.domain.NeutronNetQuota;
 import org.openstack4j.openstack.networking.internal.BaseNetworkingServices;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/VipServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/VipServiceImpl.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 import java.util.Map;
 import org.openstack4j.api.networking.ext.VipService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.ext.Vip;
 import org.openstack4j.model.network.ext.VipUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/ClusterServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/ClusterServiceImpl.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.openstack4j.api.sahara.ClusterService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.Cluster;
 import org.openstack4j.model.sahara.NodeGroup;
 import org.openstack4j.openstack.sahara.domain.SaharaCluster;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/ClusterTemplateServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/ClusterTemplateServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.sahara.internal;
 import java.util.List;
 
 import org.openstack4j.api.sahara.ClusterTemplateService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.ClusterTemplate;
 import org.openstack4j.openstack.sahara.domain.SaharaClusterTemplate;
 import org.openstack4j.openstack.sahara.domain.SaharaClusterTemplateUnwrapped;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/DataSourceServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/DataSourceServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.sahara.DataSourceService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.DataSource;
 import org.openstack4j.openstack.sahara.domain.SaharaDataSource;
 import org.openstack4j.openstack.sahara.domain.SaharaDataSource.DataSources;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobBinaryInternalServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobBinaryInternalServiceImpl.java
@@ -11,7 +11,7 @@ import org.openstack4j.core.transport.HttpEntityHandler;
 import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.model.common.Payload;
 import org.openstack4j.model.common.Payloads;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.JobBinaryInternal;
 import org.openstack4j.openstack.sahara.domain.SaharaJobBinaryInternal;
 import org.openstack4j.openstack.sahara.domain.SaharaJobBinaryInternal.JobBinaryInternals;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobBinaryServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobBinaryServiceImpl.java
@@ -10,7 +10,7 @@ import org.openstack4j.core.transport.HttpEntityHandler;
 import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.model.common.Payload;
 import org.openstack4j.model.common.Payloads;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.JobBinary;
 import org.openstack4j.openstack.sahara.domain.SaharaJobBinary;
 import org.openstack4j.openstack.sahara.domain.SaharaJobBinary.JobBinaries;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobExecutionServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobExecutionServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.sahara.JobExecutionService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.JobExecution;
 import org.openstack4j.openstack.sahara.domain.SaharaJobExecution;
 import org.openstack4j.openstack.sahara.domain.SaharaJobExecution.JobExecutions;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/JobServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.sahara.JobService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.Job;
 import org.openstack4j.model.sahara.JobConfigHint;
 import org.openstack4j.openstack.sahara.domain.SaharaJob;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/NodeGroupTemplateServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/NodeGroupTemplateServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.sahara.internal;
 import java.util.List;
 
 import org.openstack4j.api.sahara.NodeGroupTemplateService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.NodeGroupTemplate;
 import org.openstack4j.openstack.sahara.domain.SaharaNodeGroupTemplate;
 import org.openstack4j.openstack.sahara.domain.SaharaNodeGroupTemplateUnwrapped;

--- a/core/src/main/java/org/openstack4j/openstack/sahara/internal/SaharaImageServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/sahara/internal/SaharaImageServiceImpl.java
@@ -8,7 +8,7 @@ import org.openstack4j.api.sahara.SaharaImageService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
 import org.openstack4j.model.ModelEntity;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.sahara.Image;
 import org.openstack4j.openstack.sahara.domain.SaharaImage;
 import org.openstack4j.openstack.sahara.domain.SaharaImage.SaharaImages;

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockQuotaSetServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockQuotaSetServiceImpl.java
@@ -3,7 +3,7 @@ package org.openstack4j.openstack.storage.block.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.openstack4j.api.storage.BlockQuotaSetService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.BlockQuotaSet;
 import org.openstack4j.model.storage.block.BlockQuotaSetUsage;
 import org.openstack4j.openstack.storage.block.domain.CinderBlockQuotaSet;

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockVolumeServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockVolumeServiceImpl.java
@@ -9,7 +9,7 @@ import org.openstack4j.api.Apis;
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.storage.BlockVolumeService;
 import org.openstack4j.api.storage.BlockVolumeTransferService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.Volume;
 import org.openstack4j.model.storage.block.VolumeType;
 import org.openstack4j.model.storage.block.VolumeUploadImage;

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockVolumeSnapshotServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockVolumeSnapshotServiceImpl.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.storage.BlockVolumeSnapshotService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.VolumeSnapshot;
 import org.openstack4j.openstack.storage.block.domain.CinderVolumeSnapshot;
 import org.openstack4j.openstack.storage.block.domain.CinderVolumeSnapshot.VolumeSnapshots;

--- a/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockVolumeTransferServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/block/internal/BlockVolumeTransferServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.storage.BlockVolumeTransferService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.VolumeTransfer;
 import org.openstack4j.openstack.storage.block.domain.CinderVolumeTransfer;
 import org.openstack4j.openstack.storage.block.domain.CinderVolumeTransfer.VolumeTransferList;

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageContainerServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageContainerServiceImpl.java
@@ -14,7 +14,7 @@ import org.openstack4j.api.Apis;
 import org.openstack4j.api.storage.ObjectStorageContainerService;
 import org.openstack4j.api.storage.ObjectStorageObjectService;
 import org.openstack4j.core.transport.HttpResponse;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.object.SwiftContainer;
 import org.openstack4j.model.storage.object.options.ContainerListOptions;
 import org.openstack4j.model.storage.object.options.CreateUpdateContainerOptions;

--- a/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/storage/object/internal/ObjectStorageObjectServiceImpl.java
@@ -16,7 +16,7 @@ import org.openstack4j.core.transport.HttpResponse;
 import org.openstack4j.model.common.DLPayload;
 import org.openstack4j.model.common.Payload;
 import org.openstack4j.model.common.payloads.FilePayload;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.options.DownloadOptions;
 import org.openstack4j.model.storage.object.SwiftObject;
 import org.openstack4j.model.storage.object.options.ObjectListOptions;

--- a/core/src/main/java/org/openstack4j/openstack/telemetry/internal/AlarmServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/telemetry/internal/AlarmServiceImpl.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 
 import org.openstack4j.api.telemetry.AlarmService;
-import org.openstack4j.model.compute.ActionResponse;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.telemetry.Alarm;
 import org.openstack4j.openstack.telemetry.domain.CeilometerAlarm;
 


### PR DESCRIPTION
Currently the ActionResponse class is part of the
org.openstack4j.model.compute package. As it is used in most
(if not all) API service classes, it should be moved into the
org.openstack4j.model.common package.

This PR resolved #610