### PR TITLE
Unify extension list types

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/compute/ExtensionTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/compute/ExtensionTests.java
@@ -1,0 +1,55 @@
+package org.openstack4j.api.compute;
+
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.model.common.Extension;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for Nova ExtensionList
+ *
+ * @author Jeremy Unruh
+ */
+@Test(suiteName="ExtensionList")
+public class ExtensionTests extends AbstractTest {
+    private static final String JSON_EXTENSIONS = "/compute/extensions.json";
+
+    private static final DateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
+
+    @Test
+    public void testExtensions() throws Exception {
+        respondWith(JSON_EXTENSIONS);
+
+        List<? extends Extension> extensions = os().compute().listExtensions();
+        assertEquals(2, extensions.size());
+
+        Extension extension1 = extensions.get(0);
+        Extension extension2 = extensions.get(1);
+
+        assertEquals(extension1.getUpdated(), ISO8601.parse("2014-12-03T00:00:00Z"));
+        assertEquals(extension1.getName(), "Multinic");
+        assertTrue(extension1.getLinks().isEmpty());
+        assertEquals(extension1.getNamespace(), URI.create("http://docs.openstack.org/compute/ext/fake_xml"));
+        assertEquals(extension1.getAlias(), "NMN");
+        assertEquals(extension1.getDescription(), "Multiple network support.");
+
+        assertEquals(extension2.getUpdated(), ISO8601.parse("2014-12-03T00:00:00Z"));
+        assertEquals(extension2.getName(), "DiskConfig");
+        assertTrue(extension2.getLinks().isEmpty());
+        assertEquals(extension2.getNamespace(), URI.create("http://docs.openstack.org/compute/ext/fake_xml"));
+        assertEquals(extension2.getAlias(), "OS-DCF");
+        assertEquals(extension2.getDescription(), "Disk Management Extension.");
+    }
+
+    @Override
+    protected Service service() {
+        return Service.COMPUTE;
+    }
+}

--- a/core-test/src/main/resources/compute/extensions.json
+++ b/core-test/src/main/resources/compute/extensions.json
@@ -1,0 +1,24 @@
+{
+  "extensions":[
+    {
+      "updated":"2014-12-03T00:00:00Z",
+      "name":"Multinic",
+      "links":[
+
+      ],
+      "namespace":"http://docs.openstack.org/compute/ext/fake_xml",
+      "alias":"NMN",
+      "description":"Multiple network support."
+    },
+    {
+      "updated":"2014-12-03T00:00:00Z",
+      "name":"DiskConfig",
+      "links":[
+
+      ],
+      "namespace":"http://docs.openstack.org/compute/ext/fake_xml",
+      "alias":"OS-DCF",
+      "description":"Disk Management Extension."
+    }
+  ]
+}

--- a/core/src/main/java/org/openstack4j/openstack/common/ExtensionValue.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/ExtensionValue.java
@@ -75,33 +75,22 @@ public class ExtensionValue implements Extension {
 						.addValue("\n")
 						.toString();
 	}
-	
-	@JsonRootName("extensions")
-	public static class Extensions extends ListResult<ExtensionValue> {
 
+	@JsonRootName("extensions")
+	public static class ExtensionList extends ListResult<ExtensionValue> {
 		private static final long serialVersionUID = 1L;
+
 		@JsonProperty("values")
 		private List<ExtensionValue> list;
-		
-		public List<ExtensionValue> value() {
-			return list;
-		}
-	}
-	
-	public static class NovaExtensions extends ListResult<ExtensionValue> {
 
-		private static final long serialVersionUID = 1L;
-		@JsonProperty("extensions")
-		private List<ExtensionValue> list;
-		
 		public List<ExtensionValue> value() {
 			return list;
 		}
 	}
 
-	// TODO Manila extensions look exactly the same as nova extensions. Maybe they can be merged.
-	public static class ManilaExtensions extends ListResult<ExtensionValue> {
+	public static class Extensions extends ListResult<ExtensionValue> {
 		private static final long serialVersionUID = 1L;
+
 		@JsonProperty("extensions")
 		private List<ExtensionValue> list;
 

--- a/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/compute/internal/ComputeServiceImpl.java
@@ -18,7 +18,7 @@ import org.openstack4j.api.compute.ext.HypervisorService;
 import org.openstack4j.api.compute.ext.MigrationService;
 import org.openstack4j.api.compute.ext.ZoneService;
 import org.openstack4j.model.common.Extension;
-import org.openstack4j.openstack.common.ExtensionValue.NovaExtensions;
+import org.openstack4j.openstack.common.ExtensionValue.Extensions;
 
 /**
  * Compute (Nova) Operations API implementation
@@ -64,7 +64,7 @@ public class ComputeServiceImpl extends BaseComputeServices implements ComputeSe
 	 */
 	@Override
 	public List<? extends Extension> listExtensions() {
-		return get(NovaExtensions.class, uri("/extensions")).execute().getList();
+		return get(Extensions.class, uri("/extensions")).execute().getList();
 	}
 
 	/**

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/IdentityServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/IdentityServiceImpl.java
@@ -1,21 +1,17 @@
 package org.openstack4j.openstack.identity.internal;
 
-import static org.openstack4j.core.transport.ClientConstants.PATH_EXTENSIONS;
-
-import java.util.List;
-
 import org.openstack4j.api.Apis;
-import org.openstack4j.api.identity.IdentityService;
-import org.openstack4j.api.identity.RoleService;
-import org.openstack4j.api.identity.ServiceManagerService;
-import org.openstack4j.api.identity.TenantService;
-import org.openstack4j.api.identity.UserService;
+import org.openstack4j.api.identity.*;
 import org.openstack4j.model.common.Extension;
 import org.openstack4j.model.identity.Endpoint;
-import org.openstack4j.openstack.common.ExtensionValue.Extensions;
+import org.openstack4j.openstack.common.ExtensionValue;
 import org.openstack4j.openstack.identity.domain.KeystoneEndpoint.Endpoints;
 import org.openstack4j.openstack.internal.BaseOpenStackService;
 import org.openstack4j.openstack.internal.OSClientSession;
+
+import java.util.List;
+
+import static org.openstack4j.core.transport.ClientConstants.PATH_EXTENSIONS;
 
 public class IdentityServiceImpl extends BaseOpenStackService implements IdentityService {
 
@@ -31,7 +27,7 @@ public class IdentityServiceImpl extends BaseOpenStackService implements Identit
 
 	@Override
 	public List<? extends Extension> listExtensions() {
-		return get(Extensions.class, PATH_EXTENSIONS).execute().getList();
+		return get(ExtensionValue.ExtensionList.class, PATH_EXTENSIONS).execute().getList();
 	}
 
 	@Override

--- a/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/manila/internal/ShareServiceImpl.java
@@ -5,7 +5,7 @@ import org.openstack4j.api.manila.*;
 import org.openstack4j.model.common.Extension;
 import org.openstack4j.model.compute.ActionResponse;
 import org.openstack4j.model.manila.*;
-import org.openstack4j.openstack.common.ExtensionValue.ManilaExtensions;
+import org.openstack4j.openstack.common.ExtensionValue;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
 import org.openstack4j.openstack.manila.domain.ManilaAvailabilityZone;
 import org.openstack4j.openstack.manila.domain.ManilaLimits;
@@ -28,7 +28,7 @@ public class ShareServiceImpl extends BaseShareServices implements ShareService 
      */
     @Override
     public List<? extends Extension> listExtensions() {
-        return get(ManilaExtensions.class, uri("/extensions")).execute().getList();
+        return get(ExtensionValue.Extensions.class, uri("/extensions")).execute().getList();
     }
 
     /**


### PR DESCRIPTION
Openstack4j currently has three extension list types:
Extensions, NovaExtensions and ManilaExtensions. This patch
consolidates those types into two different types, which should cover
all types used by different Openstack projects: ExtensionList and
Extensions.

This resolves #612