### PR TITLE
Fixed #625 getByName failing when result list is empty 

### DIFF
--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneGroupServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneGroupServiceSpec.groovy
@@ -197,6 +197,12 @@ class KeystoneGroupServiceSpec extends AbstractSpec {
         //
         //		then: "we should no longer find the group used in this scenario"
         //		groupList.contains(group) == false
+		
+		when: "non-existent group is listed by name and domain id"
+		Group nonExistent_group_byName_byDomainId = os.identity().groups().getByName("nonExistentGroup", DOMAIN_ID)
+
+		then: "the return value should be null"
+		nonExistent_group_byName_byDomainId == null
 
         cleanup: "we delete the user used in this scenario"
         ActionResponse response_deleteUser_success = os.identity().users().delete(GROUP_CRUD_USER_ID)

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneProjectServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneProjectServiceSpec.groovy
@@ -168,10 +168,10 @@ class KeystoneProjectServiceSpec extends AbstractSpec {
         projectList_byName_empty.isEmpty() == true
 
         when: "details about a nonexistend project specified by name and domain identifier are requested"
-        os.identity().projects().getByName("nonExistentProject", PROJECT_DOMAIN_ID)
+        Project nonExistentProject_ByName = os.identity().projects().getByName("nonExistentProject", PROJECT_DOMAIN_ID)
 
         then: "this should return null"
-        thrown IndexOutOfBoundsException
+		nonExistentProject_ByName == null
 
     }
 

--- a/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneUserServiceSpec.groovy
+++ b/core-integration-test/src/test/groovy/org/openstack4j/api/identity/KeystoneUserServiceSpec.groovy
@@ -152,6 +152,12 @@ class KeystoneUserServiceSpec extends AbstractSpec {
         //        updatedUser.isEnabled() == true
         //        updatedUser.getId() == USER_CRUD_ID
         //        updatedUser.getDomainId() == USER_DOMAIN_ID
+		
+		when: "an non-existing user is 'read' by name and domain"
+		User userByName_nonExistent = os.identity().users().getByName("nonExistentUserName", USER_DOMAIN_ID)
+		
+		then: "this should return null"
+		userByName_nonExistent == null
 
         when: "roles for an existing user in domain context are requested"
         List<? extends Role> domainUserRolesList = os.identity().users().listDomainUserRoles(USER_ID, USER_DOMAIN_ID)

--- a/core-integration-test/src/test/resources/tapes/groupService_group_crud_tape.yaml
+++ b/core-integration-test/src/test/resources/tapes/groupService_group_crud_tape.yaml
@@ -286,6 +286,25 @@ interactions:
       Server: Apache/2.4.7 (Ubuntu)
       Vary: X-Auth-Token
       x-openstack-request-id: req-bf13fc70-8a3d-41ff-881a-880bc8a59f4d
+- recorded: 2016-04-08T15:57:45.354Z
+  request:
+    method: GET
+    uri: http://devstack.openstack.stack:5000/v3/groups?domain_id=default&name=nonExistentGroup
+    headers:
+      Accept: application/json
+      Host: devstack.openstack.stack:5000
+      Proxy-Connection: keep-alive
+      User-Agent: OpenStack4j / OpenStack Client
+      X-Auth-Token: 1fe0b81eedd74086b2012e190579ac9e
+  response:
+    status: 200
+    headers:
+      Content-Type: application/json
+      Date: Fri, 08 Apr 2016 16:02:52 GMT
+      Vary: X-Auth-Token
+      X-Distribution: Ubuntu
+    body: '{"links": {"self": "http://devstack.openstack.stack:5000/v3/groups", "previous": null, "next": null}, "groups": []}'
+
 - recorded: 2016-02-17T18:17:43.695Z
   request:
     method: DELETE

--- a/core-integration-test/src/test/resources/tapes/userService_user_crud_tape.yaml
+++ b/core-integration-test/src/test/resources/tapes/userService_user_crud_tape.yaml
@@ -192,6 +192,24 @@ interactions:
       Vary: X-Auth-Token
       x-openstack-request-id: req-c16339db-24bc-48dc-8711-0316a56e95e8
     body: '{"error": {"message": "Could not find user: nonExistentUserId", "code": 404, "title": "Not Found"}}'
+- recorded: 2016-04-08T15:57:50.459Z
+  request:
+    method: GET
+    uri: http://devstack.openstack.stack:5000/v3/users?domain_id=default&name=nonExistentUserName
+    headers:
+      Accept: application/json
+      Host: docker-host:5000
+      Proxy-Connection: keep-alive
+      User-Agent: OpenStack4j / OpenStack Client
+      X-Auth-Token: e699a84979b64ef9837c492b774ccbfe
+  response:
+    status: 200
+    headers:
+      Content-Type: application/json
+      Date: Fri, 08 Apr 2016 16:02:57 GMT
+      Vary: X-Auth-Token
+      X-Distribution: Ubuntu
+    body: '{"users": [], "links": {"self": "http://devstack.openstack.stack:5000/v3/users", "previous": null, "next": null}}'    
 - recorded: 2016-01-15T16:53:00.015Z
   request:
     method: GET

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneGroupServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneGroupServiceTests.java
@@ -1,5 +1,6 @@
 package org.openstack4j.api.identity;
 
+import static org.testng.AssertJUnit.assertNull;
 import static org.testng.Assert.assertEquals;
 
 import org.openstack4j.api.AbstractTest;
@@ -20,6 +21,7 @@ public class KeystoneGroupServiceTests extends AbstractTest {
     private static final String GROUP_DOMAIN_ID = "default";
     private static final String GROUP_DESCRIPTION = "Group used for CRUD tests";
     private static final String GROUP_DESCRIPTION_UPDATE = "An updated group used for CRUD tests";
+	private static final String JSON_GROUPS_EMPTY_LIST = "/identity/groups_getByName_empty.json";
 
     @Override
     protected Service service() {
@@ -64,6 +66,14 @@ public class KeystoneGroupServiceTests extends AbstractTest {
         assertEquals(updatedGroup.getDomainId(), GROUP_DOMAIN_ID);
         assertEquals(updatedGroup.getDescription(), GROUP_DESCRIPTION_UPDATE);
 
+    }
+    
+    
+    public void group_get_byName_byDomainId_NotExist_Test() throws Exception {    	
+    	respondWith(JSON_GROUPS_EMPTY_LIST);    
+    	Group group = os().identity().groups().getByName(GROUP_NAME, GROUP_DOMAIN_ID);    	
+    	assertNull(group);
+    	
     }
 
 }

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneProjectServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneProjectServiceTests.java
@@ -1,5 +1,6 @@
 package org.openstack4j.api.identity;
 
+import static org.testng.AssertJUnit.assertNull;
 import static org.testng.Assert.assertEquals;
 
 import org.openstack4j.api.AbstractTest;
@@ -16,10 +17,12 @@ public class KeystoneProjectServiceTests extends AbstractTest {
     private static final String JSON_PROJECTS_CREATE = "/identity/projects_create_response.json";
     private static final String JSON_PROJECTS_UPDATE = "/identity/projects_update_response.json";
     private static final String JSON_PROJECTS_GET_BYID = "/identity/projects_get_byId.json";
+    private static final String JSON_PROJECTS_GET_BY_NAME_EMPTY = "/identity/projects_getByName_empty.json";
     private static final String PROJECT_NAME = "ProjectX";
     private static final String PROJECT_DOMAIN_ID = "7a71863c2d1d4444b3e6c2cd36955e1e";
     private static final String PROJECT_DESCRIPTION = "Project used for CRUD tests";
     private static final String PROJECT_DESCRIPTION_UPDATE = "An updated project used for CRUD tests";
+	
     private String PROJECT_ID;
 
     @Override
@@ -72,6 +75,13 @@ public class KeystoneProjectServiceTests extends AbstractTest {
         assertEquals(updatedProject.getDomainId(), PROJECT_DOMAIN_ID);
         assertEquals(updatedProject.getDescription(), PROJECT_DESCRIPTION_UPDATE);
 
+    }
+    
+    public void projects_getByName_not_exist_test() throws Exception {
+        respondWith(JSON_PROJECTS_GET_BY_NAME_EMPTY);
+        Project project = os().identity().projects().getByName(PROJECT_NAME, PROJECT_DOMAIN_ID);
+        assertNull(project);
+    
     }
 
 }

--- a/core-test/src/main/java/org/openstack4j/api/identity/KeystoneUserServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/identity/KeystoneUserServiceTests.java
@@ -1,9 +1,12 @@
 package org.openstack4j.api.identity;
 
+import static org.testng.AssertJUnit.assertNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+
+
 
 import java.util.List;
 
@@ -26,6 +29,7 @@ public class KeystoneUserServiceTests extends AbstractTest {
     private static final String JSON_USER_GET_BYID = "/identity/user_get_byId.json";
     private static final String JSON_USER_GET_BYNAME = "/identity/user_get_byName.json";
     private static final String JSON_USER_GET_BYNAME_BYDOMAINID = "/identity/user_get_byName_byDomainId.json";
+    private static final String JSON_USER_GET_BYNAME_BYDOMAINID_NOT_EXIST = "/identity/user_get_byName_byDomainId_not_exist.json";
     private static final String JSON_USER_CREATE = "/identity/create_user.json";
     private static final String JSON_USER_READ = "/identity/read_user.json";
     private static final String JSON_USER_UPDATE = "/identity/update_user.json";
@@ -40,6 +44,7 @@ public class KeystoneUserServiceTests extends AbstractTest {
     private static final String USER_ID = "aa9f25defa6d4cafb48466df83106065";
     private static final String USER_DOMAIN_ID = "default";
     private static final String PROJECT_ID = "123ac695d4db400a9001b91bb3b8aa46";
+	
 
     /**
      * @return the identity service
@@ -111,6 +116,19 @@ public class KeystoneUserServiceTests extends AbstractTest {
         assertEquals(user.getName(), USER_NAME);
         assertEquals(user.getId(), USER_ID);
         assertEquals(user.getDomainId(), USER_DOMAIN_ID);
+    }
+    
+    /**
+     * returns null for an non-existing user when the user specified by name and domain.
+     *
+     * @throws Exception
+     */
+    public void getUser_byName_byDomainId_NotExist_Test() throws Exception {
+
+        respondWith(JSON_USER_GET_BYNAME_BYDOMAINID_NOT_EXIST);
+
+        User user = os().identity().users().getByName(USER_NAME, USER_DOMAIN_ID);
+        assertNull(user);
     }
 
     /**

--- a/core-test/src/main/resources/identity/groups_getByName_empty.json
+++ b/core-test/src/main/resources/identity/groups_getByName_empty.json
@@ -1,0 +1,8 @@
+{
+	"links": {
+		"self": "http://127.0.0.1:5000/v3/groups", 
+		"previous": null, 
+		"next": null
+		},
+	"groups": []
+}

--- a/core-test/src/main/resources/identity/projects_getByName_empty.json
+++ b/core-test/src/main/resources/identity/projects_getByName_empty.json
@@ -1,0 +1,8 @@
+{
+	"links": {
+		"self": "http://127.0.0.1:5000/v3/projects", 
+		"previous": null, 
+		"next": null
+		}, 
+	"projects": []
+}

--- a/core-test/src/main/resources/identity/user_get_byName_byDomainId_not_exist.json
+++ b/core-test/src/main/resources/identity/user_get_byName_byDomainId_not_exist.json
@@ -1,7 +1,7 @@
 {
 	"users": [], 
 	"links": {
-		"self": "http://142.133.117.163:5000/v3/users", 
+		"self": "http://127.0.0.1:5000/v3/users", 
 		"previous": null, 
 		"next": null
 		}

--- a/core-test/src/main/resources/identity/user_get_byName_byDomainId_not_exist.json
+++ b/core-test/src/main/resources/identity/user_get_byName_byDomainId_not_exist.json
@@ -1,0 +1,8 @@
+{
+	"users": [], 
+	"links": {
+		"self": "http://142.133.117.163:5000/v3/users", 
+		"previous": null, 
+		"next": null
+		}
+}

--- a/core/src/main/java/org/openstack4j/api/identity/GroupService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/GroupService.java
@@ -35,7 +35,7 @@ public interface GroupService extends RestService {
      *
      * @param groupName the group name
      * @param domainId the domain id
-     * @return the of list groups matching the name in a specific domain
+     * @return the of list groups matching the name in a specific domain or null if not found
      */
     Group getByName(String groupName, String domainId);
 

--- a/core/src/main/java/org/openstack4j/api/identity/ProjectService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/ProjectService.java
@@ -52,7 +52,7 @@ public interface ProjectService extends RestService {
 	 *
 	 * @param projectName the project name
 	 * @param domainId the domain id
-	 * @return the project
+	 * @return the project or null if not found
 	 */
 	Project getByName(String projectName, String domainId);
 

--- a/core/src/main/java/org/openstack4j/api/identity/UserService.java
+++ b/core/src/main/java/org/openstack4j/api/identity/UserService.java
@@ -37,7 +37,7 @@ public interface UserService extends RestService {
      *
      * @param userName the user name
      * @param domainId the domain identifier
-     * @return the user
+     * @return the user or null if not found
      */
 	User getByName(String userName, String domainId);
 

--- a/core/src/main/java/org/openstack4j/openstack/common/ListResult.java
+++ b/core/src/main/java/org/openstack4j/openstack/common/ListResult.java
@@ -23,4 +23,8 @@ public abstract class ListResult<T> implements ModelEntity, ListType {
 		return value();
 	}
 
+	
+    public T first() {
+    	return value().isEmpty() ? null : value().get(0);   	
+    }
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/GroupServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/GroupServiceImpl.java
@@ -33,7 +33,7 @@ public class GroupServiceImpl extends BaseOpenStackService implements GroupServi
     public Group getByName(String groupName, String domainId) {
         checkNotNull(groupName);
         checkNotNull(domainId);
-        return get(Groups.class, uri(PATH_GROUPS)).param("name", groupName).param("domain_id", domainId).execute().getList().get(0);
+        return get(Groups.class, uri(PATH_GROUPS)).param("name", groupName).param("domain_id", domainId).execute().first();
     }
 
     @Override

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/ProjectServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/ProjectServiceImpl.java
@@ -45,7 +45,7 @@ public class ProjectServiceImpl extends BaseOpenStackService implements ProjectS
     public Project getByName(String projectName, String domainId) {
         checkNotNull(projectName);
         checkNotNull(domainId);
-        return get(Projects.class, uri(PATH_PROJECTS)).param("name", projectName).param("domain_id", domainId).execute().getList().get(0);
+        return get(Projects.class, uri(PATH_PROJECTS)).param("name", projectName).param("domain_id", domainId).execute().first();
     }
 
     @Override

--- a/core/src/main/java/org/openstack4j/openstack/identity/internal/UserServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/internal/UserServiceImpl.java
@@ -51,8 +51,8 @@ public class UserServiceImpl extends BaseOpenStackService implements UserService
     @Override
     public User getByName(String userName, String domainId) {
         checkNotNull(userName);
-        checkNotNull(domainId);
-        return get(Users.class, uri(PATH_USERS)).param("name", userName).param("domain_id", domainId).execute().getList().get(0);
+        checkNotNull(domainId);        
+        return get(Users.class, uri(PATH_USERS)).param("name", userName).param("domain_id", domainId).execute().first();
     }
 
     /**


### PR DESCRIPTION
Added Test Cases for failing getByName in 

org.openstack4j.openstack.identity.internal.GroupServiceImpl.getByName(String, String)
org.openstack4j.openstack.identity.internal.ProjectServiceImpl.getByName(String, String)
org.openstack4j.openstack.identity.internal.UserServiceImpl.getByName(String, String)

And fixed the problem by adding a first() method in ListResult<T> and calling it from the respective implementations.

Let me know what you think.